### PR TITLE
C2TSの新しいpublic APIを利用することでtestable importをやめる

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "893cc097f701644d059d8314af7c4dc53ecb5f6b",
-        "version" : "1.4.0"
+        "revision" : "93906630891fa8c442534ed86df50bc9c38c857f",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.4.0"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.5.0"),
     ],
     targets: [
         .executableTarget(

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public protocol EchoServiceProtocol {
     func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse
+
+    func testComplexType(request: TestComplexType.Request) async throws -> TestComplexType.Response
 }
 
 public struct EchoHelloRequest: Codable, Sendable {
@@ -18,4 +20,36 @@ public struct EchoHelloResponse: Codable, Sendable {
     }
 
     public var message: String
+}
+
+public enum TestComplexType {
+    public struct K<T>: Codable & Sendable where T: Codable & Sendable {
+        public var x: T
+    }
+
+    public enum E<T>: Codable & Sendable where T: Codable & Sendable {
+        case k(K<T>)
+        case i(Int)
+        case n
+    }
+
+    public struct L: Codable & Sendable {
+        public var x: String
+    }
+
+    public struct Request: Codable & Sendable {
+        public var a: K<[E<L>?]>?
+
+        public init(a: K<[E<L>?]>?) {
+            self.a = a
+        }
+    }
+
+    public struct Response: Codable & Sendable {
+        public var a: K<[E<L>?]>?
+
+        public init(a: K<[E<L>?]>?) {
+            self.a = a
+        }
+    }
 }

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -9,4 +9,7 @@ public struct EchoServiceStub: EchoServiceProtocol, Sendable {
     public func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse {
         return try await client.send(path: "Echo/hello", request: request)
     }
+    public func testComplexType(request: TestComplexType.Request) async throws -> Response {
+        return try await client.send(path: "Echo/testComplexType", request: request)
+    }
 }

--- a/example/Sources/Server/Gen/Echo.gen.swift
+++ b/example/Sources/Server/Gen/Echo.gen.swift
@@ -14,6 +14,9 @@ struct EchoServiceProvider<RequestHandler: RawRequestHandler, Service: EchoServi
             group.post("hello", use: requestHandler.makeHandler(serviceBuilder) { s, r in
                 try await s.hello(request: r)
             })
+            group.post("testComplexType", use: requestHandler.makeHandler(serviceBuilder) { s, r in
+                try await s.testComplexType(request: r)
+            })
         }
     }
 }

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -10,4 +10,8 @@ struct EchoService: EchoServiceProtocol {
             message: "Hello, \(request.name)!"
         )
     }
+
+    func testComplexType(request: TestComplexType.Request) async throws -> TestComplexType.Response {
+        .init(a: request.a)
+    }
 }

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -1,7 +1,9 @@
-import { IRawClient } from "./common.gen";
+import { IRawClient } from "./common.gen.js";
+import { Array_decode, OptionalField_decode, Optional_decode, identity } from "./decode.gen.js";
 
 export interface IEchoClient {
   hello(request: EchoHelloRequest): Promise<EchoHelloResponse>
+  testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response>
 }
 
 class EchoClient implements IEchoClient {
@@ -14,6 +16,10 @@ class EchoClient implements IEchoClient {
   async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
     return await this.rawClient.fetch(request, "Echo/hello") as EchoHelloResponse
   }
+  async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
+    const json = await this.rawClient.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON
+    return TestComplexType_Response_decode(json)
+  }
 }
 
 export const buildEchoClient = (raw: IRawClient): IEchoClient => new EchoClient(raw);
@@ -25,3 +31,121 @@ export type EchoHelloRequest = {
 export type EchoHelloResponse = {
     message: string;
 };
+
+export type TestComplexType = never;
+
+export type TestComplexType_K<T> = {
+    x: T;
+};
+
+export type TestComplexType_K_JSON<T_JSON> = {
+    x: T_JSON;
+};
+
+export function TestComplexType_K_decode<T, T_JSON>(json: TestComplexType_K_JSON<T_JSON>, T_decode: (json: T_JSON) => T): TestComplexType_K<T> {
+    return {
+        x: T_decode(json.x)
+    };
+}
+
+export type TestComplexType_E<T> = {
+    kind: "k";
+    k: {
+        _0: TestComplexType_K<T>;
+    };
+} | {
+    kind: "i";
+    i: {
+        _0: number;
+    };
+} | {
+    kind: "n";
+    n: {};
+};
+
+export type TestComplexType_E_JSON<T_JSON> = {
+    k: {
+        _0: TestComplexType_K_JSON<T_JSON>;
+    };
+} | {
+    i: {
+        _0: number;
+    };
+} | {
+    n: {};
+};
+
+export function TestComplexType_E_decode<T, T_JSON>(json: TestComplexType_E_JSON<T_JSON>, T_decode: (json: T_JSON) => T): TestComplexType_E<T> {
+    if ("k" in json) {
+        const j = json.k;
+        return {
+            kind: "k",
+            k: {
+                _0: TestComplexType_K_decode(j._0, T_decode)
+            }
+        };
+    } else if ("i" in json) {
+        const j = json.i;
+        return {
+            kind: "i",
+            i: {
+                _0: j._0
+            }
+        };
+    } else if ("n" in json) {
+        return {
+            kind: "n",
+            n: {}
+        };
+    } else {
+        throw new Error("unknown kind");
+    }
+}
+
+export type TestComplexType_L = {
+    x: string;
+};
+
+export type TestComplexType_Request = {
+    a?: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>;
+};
+
+export type TestComplexType_Request_JSON = {
+    a?: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>;
+};
+
+export function TestComplexType_Request_decode(json: TestComplexType_Request_JSON): TestComplexType_Request {
+    return {
+        a: OptionalField_decode(json.a, (json: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
+            return TestComplexType_K_decode(json, (json: (TestComplexType_E_JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
+                return Array_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
+                    return Optional_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
+                        return TestComplexType_E_decode(json, identity);
+                    });
+                });
+            });
+        })
+    };
+}
+
+export type TestComplexType_Response = {
+    a?: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>;
+};
+
+export type TestComplexType_Response_JSON = {
+    a?: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>;
+};
+
+export function TestComplexType_Response_decode(json: TestComplexType_Response_JSON): TestComplexType_Response {
+    return {
+        a: OptionalField_decode(json.a, (json: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
+            return TestComplexType_K_decode(json, (json: (TestComplexType_E_JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
+                return Array_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
+                    return Optional_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
+                        return TestComplexType_E_decode(json, identity);
+                    });
+                });
+            });
+        })
+    };
+}

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -5,8 +5,24 @@ async function main() {
   const rawClient = new RawAPIClient("http://127.0.0.1:8080");
   const echoClient = buildEchoClient(rawClient);
 
-  const res = await echoClient.hello({ name: "TypeScript" });
-  console.log(res.message);
+  {
+    const res = await echoClient.hello({ name: "TypeScript" });
+    console.log(res.message);
+  }
+  
+  {
+    const res = await echoClient.testComplexType({
+      a: {
+        x: [
+          { k: { _0: { x: { x: "hello" } } } },
+          { i: { _0: 100 } },
+          { n: {} },
+          null
+        ]
+      }
+    })
+    console.log(JSON.stringify(res));
+  }
 }
 
 main();


### PR DESCRIPTION
# その他の変更の補足説明

`CodeGenerator` は `struct` ですが、内部にキャッシュを持っています。
そのため、同じSwiftソースセットから得られた型を扱う限りにおいては、
同じオブジェクトを使い続けるほうが望ましいです。
なお、あくまでキャッシュであって、プロパティが変わらない限り動作結果は同一です。
そのため、プロパティが変わるとキャッシュがクリアされます。

ちなみにそのキャッシュ用途は、
「ある型がJSON型をもつかどうか」の判定結果です。
これが理論上指数的な計算負荷を持ちそうだったのでメモ化しています。

まあ現実的には問題になりそうにないのでお作法の問題です。

そこで、元実装は `TypeMap` を取り回していますが、
これを、最初に作った `CodeGenerator` を取り回すように変更しました。

---

`DependencyScanner` を `public` にして、
`CodeGenerator.scanDependency` を削除したので、
それに合わせて `DependencyScanner` を直接使うようにしました。

というのも、 `DependencyScanner` は `knownNames` は要求しますが、
純粋に `TSCode` を読み取るだけのオブジェクトで、
c2ts特有のCodableやJSON型を意識したロジックには関心が無いので、
`CodeGenerator` の APIになっていると、
無意味な `CodeGenerator` の再生成を促しうるので分離しました。



