### PR TITLE
move codegen script to package plugin

### DIFF
--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "codabletotypescript",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/CodableToTypeScript",
+      "state" : {
+        "revision" : "93906630891fa8c442534ed86df50bc9c38c857f",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "console-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
@@ -43,6 +52,15 @@
       "state" : {
         "revision" : "5603b81ceb744b8318feab1e60943704977a866b",
         "version" : "4.3.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
       }
     },
     {
@@ -124,6 +142,24 @@
       "state" : {
         "revision" : "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
         "version" : "1.11.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
+        "version" : "0.50600.1"
+      }
+    },
+    {
+      "identity" : "swifttypereader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/SwiftTypeReader",
+      "state" : {
+        "revision" : "6b1b8b72f2ffbdae48fc1dd214e3c8eff55c8e1c",
+        "version" : "1.1.3"
       }
     },
     {

--- a/example/Package.swift
+++ b/example/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "MyApplication",
     platforms: [.macOS(.v12)],
     dependencies: [
+        .package(path: "../"),
         .package(url: "https://github.com/vapor/vapor", from: "4.57.0"),
     ],
     targets: [
@@ -29,5 +30,15 @@ let package = Package(
                 "APIDefinition",
             ]
         ),
+        .plugin(
+            name: "CodegenPlugin",
+            capability: .command(
+                intent: .custom(verb: "codegen", description: "Generate codes from Sources/APIDefinition"),
+                permissions: [.writeToPackageDirectory(reason: "Place generated code")]
+            ),
+            dependencies: [
+                .product(name: "codegen", package: "CallableKit"),
+            ]
+        )
     ]
 )

--- a/example/Plugins/CodegenPlugin/CodegenPlugin.swift
+++ b/example/Plugins/CodegenPlugin/CodegenPlugin.swift
@@ -1,0 +1,30 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct CodegenPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) async throws {
+        let codegenTool = try context.tool(named: "codegen")
+        let codegenExec = URL(fileURLWithPath: codegenTool.path.string)
+
+        let arguments: [String] = [
+            "Sources/APIDefinition",
+            "--client_out", "Sources/Client/Gen",
+            "--vapor_out", "Sources/Server/Gen",
+            "--ts_out", "TSClient/src/Gen",
+        ]
+
+        let process = try Process.run(codegenExec, arguments: arguments)
+        process.waitUntilExit()
+
+        if process.terminationReason == .exit && process.terminationStatus == 0 {
+            // ok. do nothing
+        } else {
+            let problem = "\(process.terminationReason):\(process.terminationStatus)"
+            Diagnostics.error("codegen invocation failed: \(problem)")
+        }
+    }
+}

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,10 @@
 # example
 
 A description of this package.
+
+## Codegen
+
+```sh
+swift package --allow-writing-to-package-directory codegen
+```
+

--- a/example/codegen.sh
+++ b/example/codegen.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -ex
-
-DIR=$(cd $(dirname $0); pwd)
-
-cd "$DIR/.."
-swift run codegen "$DIR/Sources/APIDefinition" \
-    --client_out "$DIR/Sources/Client/Gen" \
-    --vapor_out "$DIR/Sources/Server/Gen" \
-    --ts_out "$DIR/TSClient/src/Gen"


### PR DESCRIPTION
シェルスクリプトではなくswift package pluginを用いてコード生成を行う。
シェルスクリプトに比べて、`codegen` executableをSwiftPM経由で取得するのでポータビリティがある。