### PR TITLE
TSコード生成を完全にASTで実装する

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "93906630891fa8c442534ed86df50bc9c38c857f",
-        "version" : "1.5.0"
+        "revision" : "8175ccee523ea0068591ffa2b0481beff7fca97f",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.5.0"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.6.0")
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.6.0")
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "1.6.0"),
     ],
     targets: [
         .executableTarget(

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "codabletotypescript",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/CodableToTypeScript",
-      "state" : {
-        "revision" : "93906630891fa8c442534ed86df50bc9c38c857f",
-        "version" : "1.5.0"
-      }
-    },
-    {
       "identity" : "console-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -1,25 +1,35 @@
-import { IRawClient } from "./common.gen.js";
-import { Array_decode, OptionalField_decode, Optional_decode, identity } from "./decode.gen.js";
+import {
+    IRawClient
+} from "./common.gen.js";
+
+import {
+    Array_decode,
+    OptionalField_decode,
+    Optional_decode,
+    identity
+} from "./decode.gen.js";
 
 export interface IEchoClient {
-  hello(request: EchoHelloRequest): Promise<EchoHelloResponse>
-  testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response>
+    hello(request: EchoHelloRequest): Promise<EchoHelloResponse>;
+
+    testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response>;
 }
 
 class EchoClient implements IEchoClient {
-  rawClient: IRawClient;
+    rawClient: IRawClient;
 
-  constructor(rawClient: IRawClient) {
-    this.rawClient = rawClient;
-  }
+    constructor(rawClient: IRawClient) {
+        this.rawClient = rawClient;
+    }
 
-  async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
-    return await this.rawClient.fetch(request, "Echo/hello") as EchoHelloResponse
-  }
-  async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
-    const json = await this.rawClient.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON
-    return TestComplexType_Response_decode(json)
-  }
+    async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
+        return await this.rawClient.fetch(request, "Echo/hello") as EchoHelloResponse;
+    }
+
+    async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
+        const json = await this.rawClient.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
+        return TestComplexType_Response_decode(json);
+    }
 }
 
 export const buildEchoClient = (raw: IRawClient): IEchoClient => new EchoClient(raw);


### PR DESCRIPTION
C2TS 1.6.0 でTSのAST対応を増やしたので、
それを使ってTSコードの生成をするように書き換えました。
(というか、C2TSの改修内容は、ここで必要になるものを追加しました。)

これにより、`import` が必要なシンボルの列挙を、
C2TSの `DependencyScanner` に任せる事ができるようになりました。
そして、シンボルの利用を追跡するロジックを削除することができました。

---

現状では必要なシンボルがどのファイルにあるのかは、わからないので、
`ImportMap` の利用は継続しています。

生成コードのASTから、「そのソースコードでexportされたシンボル一覧」
を取得する機能を作ればC2TSだけで対応する事もできそうです。
これはimportが必要なシンボルを求める時に、
内部的には取得している情報なので、実現できそうです。

---

残念ながら、文字列を直接組み立てるのと比べると、
ASTを組み立てるコードは量が多くなってしまいます。

SwiftSyntaxは同様の問題に対して、
文字列をパースしてASTに変換するAPIを用意することで、
文字列のほうが楽な場合はそこだけ文字列合成でASTを実装できます。

ですが、これをやるにはSwift実装のTypeScriptパーサが必要になるので、
対応は厳しそうです。

---

ASTが未対応のコードを生成したい場合、
C2TSの対応を待たずに実装するためには、
`TSCustomDecl`, `TSCustomStmt`, `TSCustomExpr` を使用する事ができます。
これらのノードは任意の文字列をAST中に挿入できます。

しかし、この文字列に対してはシンボル解析ができないので、
カスタムノード中で新たなシンボル利用があると、
生成されるimport文に不足が出てしまいます。

ここについては、カスタムノード自身が、
ソースコード文字列とは別で、
利用しているシンボルリストを保持できる改修をすれば、
解決できます。

---

メリットとデメリットのある変更ですが、
CallableKitのTSコードの生成内容が変化する見込みが薄いのであれば、
デメリットが顕在化するリスクは低いと思いますが、
いかがでしょうか。