### PR TITLE
Fix response type name for nested type

### DIFF
--- a/Sources/Codegen/ServiceProtocolScanner.swift
+++ b/Sources/Codegen/ServiceProtocolScanner.swift
@@ -50,8 +50,11 @@ enum ServiceProtocolScanner {
                 request: fdecl.parameters.first.map {
                     .init(argName: $0.name, typeName: $0.unresolvedType.description, raw: try! $0.type())
                 },
-                response: try! fdecl.outputType().map {
-                    .init(typeName: $0.name, raw: $0)
+                response: try! fdecl.unresolvedOutputType.map {
+                    .init(
+                        typeName: $0.description,
+                        raw: try $0.resolved()  // INFO: 後段の利用のために先にresolveする。 https://github.com/omochi/CodableToTypeScript/issues/23
+                    )
                 },
                 raw: fdecl
             )

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "codabletotypescript",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/CodableToTypeScript",
+      "state" : {
+        "revision" : "8175ccee523ea0068591ffa2b0481beff7fca97f",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "console-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -9,7 +9,7 @@ public struct EchoServiceStub: EchoServiceProtocol, Sendable {
     public func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse {
         return try await client.send(path: "Echo/hello", request: request)
     }
-    public func testComplexType(request: TestComplexType.Request) async throws -> Response {
+    public func testComplexType(request: TestComplexType.Request) async throws -> TestComplexType.Response {
         return try await client.send(path: "Echo/testComplexType", request: request)
     }
 }


### PR DESCRIPTION
レスポンス型にネストした型が含まれていた場合、Swiftクライアント向けのコードがコンパイルエラーになっていた問題を修正