### PR TITLE
Add nextjs flag

### DIFF
--- a/Sources/Codegen/Codegen.swift
+++ b/Sources/Codegen/Codegen.swift
@@ -24,6 +24,9 @@ enum CodegenError: Error {
     @Argument(help: "directory path of definition codes", completion: .directory)
     var definitionDirectory: URL
 
+    @Flag(help: "use import decl of Next.js style")
+    var nextjs: Bool = false
+
     mutating func run() throws {
         let moduleName = definitionDirectory
             .resolvingSymlinksInPath()
@@ -62,9 +65,10 @@ enum CodegenError: Error {
         }
 
         if let ts_out = ts_out {
-            try GenerateNextClient(
+            try GenerateTSClient(
                 srcDirectory: definitionDirectory,
-                dstDirectory: ts_out
+                dstDirectory: ts_out,
+                nextjs: nextjs
             ).run()
         }
     }

--- a/Sources/Codegen/GenerateTSClient.swift
+++ b/Sources/Codegen/GenerateTSClient.swift
@@ -29,9 +29,11 @@ class ImportMap {
     }
 }
 
-struct GenerateNextClient {
+struct GenerateTSClient {
     var srcDirectory: URL
     var dstDirectory: URL
+    var nextjs: Bool
+
     private let importMap = ImportMap(defs: [
         (TSIdentifier("IRawClient"), "common.gen.ts"),
         (TSIdentifier("identity"), "decode.gen.ts"),
@@ -220,7 +222,11 @@ export interface IRawClient {
             let names = nameMap[file] ?? []
             var file = file
             if file.hasSuffix(".ts") {
-                file = "./" + (file as NSString).deletingPathExtension + ".js"
+                if nextjs {
+                    file = "./" + (file as NSString).deletingPathExtension
+                } else {
+                    file = "./" + (file as NSString).deletingPathExtension + ".js"
+                }
             }
             return TSImportDecl(names: names, from: file)
         }


### PR DESCRIPTION
Next.jsは `from './foo.js'` の形式のimport文に対応していない。

詳細

- https://github.com/vercel/next.js/issues/33056
- https://github.com/vercel/next.js/discussions/32237

TypeScriptはimport文に`.js`拡張子を使うことを想定してそうであるので、それを遵守したい。
https://www.typescriptlang.org/docs/handbook/2/modules.html

直る見込みがなさそうなので、Next.js用に専用フラグを用意して分岐する。基本は`.js`をつける。