### PR TITLE
CodableToTypeScriptのアップグレードに追従する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.swiftpm

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ xcuserdata/
 DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm/xcode/xcshareddata/xcschemes/*.xcscheme
 .netrc
-.swiftpm

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "e3540954f4f0849c6150cc87a4c9e94823b94571",
-        "version" : "1.8.1"
+        "branch" : "str-2",
+        "revision" : "e37f8d69ffbc73b76e5926d41892bea3fe90e13c"
       }
     },
     {
@@ -16,6 +16,15 @@
       "state" : {
         "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "e142916c4fec656c150a615bd22f569d2c09d7dc",
-        "version" : "1.1.5"
+        "branch" : "decl-repr",
+        "revision" : "55a546f41f61d402eeaee131cb39c2b624688758"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "main",
-        "revision" : "6f601d6ba1e37f60ffefd1f8509fae6edeb49656"
+        "revision" : "f7c9c5ab09e54c2ff8bcd7bb0295241099294955",
+        "version" : "2.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "main",
-        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae"
+        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae",
+        "version" : "2.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "str-2",
-        "revision" : "e37f8d69ffbc73b76e5926d41892bea3fe90e13c"
+        "branch" : "main",
+        "revision" : "6f601d6ba1e37f60ffefd1f8509fae6edeb49656"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "decl-repr",
-        "revision" : "55a546f41f61d402eeaee131cb39c2b624688758"
+        "branch" : "main",
+        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "main"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "main"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.0.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", .upToNextMinor(from: "1.8.1")),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", .upToNextMinor(from: "1.1.5")),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "str-2"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "decl-repr"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "str-2"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "decl-repr"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "main"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "main"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/Codegen/GenerateSwiftClient.swift
+++ b/Sources/Codegen/GenerateSwiftClient.swift
@@ -92,7 +92,7 @@ extension StubClientProtocol {
         }
         if stubs.isEmpty { return nil }
 
-        let imports: String = Set([definitionModule] + file.imports.map(\.name))
+        let imports: String = Set([definitionModule] + file.imports.map(\.moduleName))
             .sorted()
             .map({ "import \($0)" })
             .joined(separator: "\n")

--- a/Sources/Codegen/GenerateTSClient.swift
+++ b/Sources/Codegen/GenerateTSClient.swift
@@ -272,9 +272,9 @@ export interface IRawClient {
         var g = Generator(definitionModule: definitionModule, srcDirectory: srcDirectory, dstDirectory: dstDirectory, dependencies: dependencies)
         g.isOutputFileName = { $0.hasSuffix(".gen.ts") }
 
-        let generator = CodeGenerator(typeMap: typeMap)
-
         try g.run { input, write in
+            let generator = CodeGenerator(context: input.context, typeMap: typeMap)
+
             let common = Generator.OutputFile(
                 name: "common.gen.ts",
                 content: generateCommon()

--- a/Sources/Codegen/GenerateTSClient.swift
+++ b/Sources/Codegen/GenerateTSClient.swift
@@ -10,19 +10,26 @@ fileprivate class ImportMap {
     }
 
     var defs: [Def] = []
-    func insert(type: SType, file: String, generator: CodeGenerator) throws {
-        let tsType = TSIdentifier(try generator.transpileTypeReference(type: type).description)
-        if self.file(for: tsType) != nil {
-            throw MessageError("Duplicated type: \(tsType). Using the same type name in multiple modules is not supported.")
+    func insert(type: any SType, file: String, generator: CodeGenerator) throws {
+        guard let tsType = try generator.transpileTypeReference(type: type).named else {
+            return
         }
 
-        defs.append((tsType, file))
+        let tsTypeName = TSIdentifier(tsType.name)
+        if self.file(for: tsTypeName) != nil {
+            throw MessageError("Duplicated type: \(tsTypeName). Using the same type name in multiple modules is not supported.")
+        }
+
+        defs.append((tsTypeName, file))
 
         if try generator.hasTranspiledJSONType(type: type) {
-            let tsJsonType = try generator.transpileTypeReferenceToJSON(type: type)
-            defs.append((TSIdentifier(tsJsonType.description), file))
+            if let tsJsonType = try generator.transpileTypeReferenceToJSON(type: type).named {
+                defs.append((TSIdentifier(tsJsonType.name), file))
+            }
 
-            if let tsDecodeFunc = try generator.generateDecodeFunction(type: type) {
+            if let type = type as? any NominalType,
+               let tsDecodeFunc = try generator.generateDecodeFunction(type: type.nominalTypeDecl)
+            {
                 defs.append((TSIdentifier(tsDecodeFunc.name), file))
             }
         }
@@ -30,6 +37,18 @@ fileprivate class ImportMap {
 
     func file(for typeName: TSIdentifier) -> String? {
         defs.first(where: { $0.typeName == typeName })?.fileName
+    }
+}
+
+extension GenericTypeDecl {
+    func walk(body: (any GenericTypeDecl) throws -> Void) rethrows {
+        try body(self)
+
+        if let self = self as? any NominalTypeDecl {
+            for type in self.types {
+                try type.walk(body: body)
+            }
+        }
     }
 }
 
@@ -53,8 +72,11 @@ struct GenerateTSClient {
         var typeMapTable: [String: String] = TypeMap.defaultTable
         typeMapTable["URL"] = "string"
         typeMapTable["Date"] = "string"
-        return TypeMap(table: typeMapTable) { typeSpecifier in
-            if typeSpecifier.lastElement.name.hasSuffix("ID") {
+        return TypeMap(table: typeMapTable) { typeRepr in
+            if let typeRepr = typeRepr as? IdentTypeRepr,
+               let lastElement = typeRepr.elements.last,
+               lastElement.name.hasSuffix("ID")
+            {
                 return "string"
             }
             return nil
@@ -191,21 +213,17 @@ export interface IRawClient {
 
         // Request・Response型定義の出力
         for stype in file.types {
-            guard stype.struct != nil
-                    || (stype.enum != nil && !stype.enum!.caseElements.isEmpty)
-                    || stype.regular?.types.isEmpty == false
+            guard stype is StructDecl
+                    || ((stype as? EnumDecl)?.caseElements.isEmpty ?? true) == false
+                    || stype.types.isEmpty == false
             else {
                 continue
             }
 
             // 型定義とjson変換関数だけを抜き出し
-            func walk(stype: SType) throws {
+            try stype.walk { (stype) in
                 codes += try generator.generateTypeOwnDeclarations(type: stype).decls
-                for stype in stype.regular?.types ?? [] {
-                    try walk(stype: stype)
-                }
             }
-            try walk(stype: stype)
         }
 
         if codes.isEmpty { return nil }
@@ -273,15 +291,10 @@ export interface IRawClient {
             for inputFile in input.files {
                 let outputFile = outputFilename(for: inputFile)
 
-                func walk(stype: SType) throws {
-                    try importMap.insert(type: stype, file: outputFile, generator: generator)
-                    for stype in stype.regular?.types ?? [] {
-                        try walk(stype: stype)
-                    }
-                }
-
                 for stype in inputFile.types {
-                    try walk(stype: stype)
+                    try stype.walk { (stype) in
+                        try importMap.insert(type: stype.declaredInterfaceType, file: outputFile, generator: generator)
+                    }
                 }
             }
 
@@ -299,12 +312,12 @@ export interface IRawClient {
 }
 
 extension CodeGenerator {
-    fileprivate func tsName(stype: SType) throws -> TSIdentifier {
+    fileprivate func tsName(stype: any SType) throws -> TSIdentifier {
         let tsType = try transpileTypeReference(type: stype)
         return .init(tsType.description)
     }
 
-    fileprivate func tsJsonName(stype: SType) throws -> TSIdentifier {
+    fileprivate func tsJsonName(stype: any SType) throws -> TSIdentifier {
         let tsType = try transpileTypeReferenceToJSON(type: stype)
         return .init(tsType.description)
     }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "main",
-        "revision" : "6f601d6ba1e37f60ffefd1f8509fae6edeb49656"
+        "revision" : "f7c9c5ab09e54c2ff8bcd7bb0295241099294955",
+        "version" : "2.0.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "main",
-        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae"
+        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae",
+        "version" : "2.0.0"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "e3540954f4f0849c6150cc87a4c9e94823b94571",
-        "version" : "1.8.1"
+        "branch" : "str-2",
+        "revision" : "e37f8d69ffbc73b76e5926d41892bea3fe90e13c"
       }
     },
     {
@@ -70,6 +70,15 @@
       "state" : {
         "revision" : "d3e04a9d4b3833363fb6192065b763310b156d54",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "e142916c4fec656c150a615bd22f569d2c09d7dc",
-        "version" : "1.1.5"
+        "branch" : "decl-repr",
+        "revision" : "55a546f41f61d402eeaee131cb39c2b624688758"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
-        "version" : "1.9.0"
+        "revision" : "5bee16a79922e3efcb5cea06ecd27e6f8048b56b",
+        "version" : "1.13.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "e2f741640364c1d271405da637029ea6a33f754e",
-        "version" : "1.11.1"
+        "revision" : "3be4b6418d1e8b835b0b1a1bee06b249faa4da5f",
+        "version" : "1.14.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "str-2",
-        "revision" : "e37f8d69ffbc73b76e5926d41892bea3fe90e13c"
+        "branch" : "main",
+        "revision" : "6f601d6ba1e37f60ffefd1f8509fae6edeb49656"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "75ea3b627d88221440b878e5dfccc73fd06842ed",
-        "version" : "4.2.7"
+        "revision" : "a7e67a1719933318b5ab7eaaed355cde020465b1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/multipart-kit.git",
       "state" : {
-        "revision" : "2dd9368a3c9580792b77c7ef364f3735909d9996",
-        "version" : "4.5.1"
+        "revision" : "0d55c35e788451ee27222783c7d363cb88092fab",
+        "version" : "4.5.2"
       }
     },
     {
@@ -50,8 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",
       "state" : {
-        "revision" : "5603b81ceb744b8318feab1e60943704977a866b",
-        "version" : "4.3.1"
+        "revision" : "ffac7b3a127ce1e85fb232f1a6271164628809ad",
+        "version" : "4.6.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+        "version" : "1.0.0"
       }
     },
     {
@@ -59,8 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+        "version" : "1.0.2"
       }
     },
     {
@@ -68,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-backtrace.git",
       "state" : {
-        "revision" : "d3e04a9d4b3833363fb6192065b763310b156d54",
-        "version" : "1.3.1"
+        "revision" : "f25620d5d05e2f1ba27154b40cafea2b67566956",
+        "version" : "1.3.3"
       }
     },
     {
@@ -86,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "067254c79435de759aeef4a6a03e43d087d61312",
-        "version" : "2.0.5"
+        "revision" : "f652300628eb2003449e627f1f394a27ea2af9a8",
+        "version" : "2.2.0"
       }
     },
     {
@@ -95,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "eadb828f878fed144387e3845866225bb7082c56",
-        "version" : "2.3.0"
+        "revision" : "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
+        "version" : "2.3.2"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "d6e3762e0a5f7ede652559f53623baf11006e17c",
-        "version" : "2.39.0"
+        "revision" : "edfceecba13d68c1c993382806e72f7e96feaa86",
+        "version" : "2.44.0"
       }
     },
     {
@@ -122,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-        "version" : "1.10.2"
+        "revision" : "91dd2d61fb772e1311bb5f13b59266b579d77e42",
+        "version" : "1.15.0"
       }
     },
     {
@@ -131,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "50c25c132b140e62b45e90b5a76f13ded02c8a46",
-        "version" : "1.20.1"
+        "revision" : "d6656967f33ed8b368b38e4b198631fc7c484a40",
+        "version" : "1.23.1"
       }
     },
     {
@@ -140,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "b5260a31c2a72a89fa684f5efb3054d8725a2316",
-        "version" : "2.18.0"
+        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
+        "version" : "2.23.0"
       }
     },
     {
@@ -149,8 +167,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-        "version" : "1.11.4"
+        "revision" : "c0d9a144cfaec8d3d596aadde3039286a266c15c",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
       }
     },
     {
@@ -167,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "decl-repr",
-        "revision" : "55a546f41f61d402eeaee131cb39c2b624688758"
+        "branch" : "main",
+        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae"
       }
     },
     {
@@ -176,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor",
       "state" : {
-        "revision" : "b05266f863ee93eeff4b6d075364ccc8f81bbc1e",
-        "version" : "4.57.0"
+        "revision" : "2d54398d50951f177eb899c05154636e381f3bc6",
+        "version" : "4.67.4"
       }
     },
     {
@@ -185,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "e32033ad3c68ebec1b761bc961be7bd56bad02f8",
-        "version" : "2.3.1"
+        "revision" : "2d9d2188a08eef4a869d368daab21b3c08510991",
+        "version" : "2.6.1"
       }
     }
   ],


### PR DESCRIPTION
SwiftTypeReaderの大改修に追従します。
https://github.com/omochi/SwiftTypeReader/releases/tag/2.0.0

それにCodableToTypeScriptも追従するので、これにも追従します。
https://github.com/omochi/CodableToTypeScript/releases/tag/2.0.0

SwiftTypeReaderのAPIや設計の変化に関してはここに解説を書きました。
https://github.com/omochi/SwiftTypeReader/blob/main/Docs/v2-migration-guide.md

exampleの動作チェックをして、全く同じTypeScriptコードが生成される事を確認しました。

見えやすい差としては、 `any SType` を受けるところと `any TypeDecl` を受けるところの使い分けがあります。

`SType` はメタタイプの実体を意味していて、ジェネリック引数が束縛されています。値型のセマンティクスを持ちます。
`TypeDecl` はコード上の宣言を指していて、参照型のセマンティクスを持ちます。
例えば2つの型 `S<A>` と `S<B>` があるとき、これが同じ `S` なのかどうかは `decl` の同値性を見ればよいです。
型パラメータも含めた同値性は型を直接比較すればよいです。
その型にどういうプロパティがあるか、といった情報は `TypeDecl` に書かれています。

対応するDeclを持たない型もあります。
例えば関数型(`FunctionType`)がそうです。

よって、使い分け方としてざっくり言えば、`SType` が万能で広い表現範囲を持っています。
そして `SType` の一部からは対応する `TypeDecl` を取り出せます。

例えば、 `transpileTypeReference` は、様々な型の表記を TypeScript に持っていきたいし、
割り当てられたジェネリック引数の情報も引き回す必要があるので、`SType` を引数に取っています。

一方、 `generateTypeDeclaration` は、 TypeScript 側で型の定義を実装せねばならず、
構造などの情報が取れる型でなければ意味がないし、
そこではジェネリックパラメータ定義は必要ですが、割り当てられたジェネリック引数は意味がないので、
`TypeDecl` に狭めた引数を取っています。

`TypeDecl` から型に戻す場合は `declaredTypeInterface` プロパティを使います。

もう一つ大きな変化は `TypeRepr` です。
従来は `A.B.C` 形式しか考慮していませんでしたが、
実際には `[A.B]` とか `(A) -> B` のような形もあります。
これを扱えるように抽象化しました。
そのため、従来のような型名の判定は `IdentTypeRepr` へのダウンキャストが必要になりました。