### PR TITLE
CodableToTypeScriptをアップグレードして、TypeScriptASTによるコード生成に書き換える

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "f7c9c5ab09e54c2ff8bcd7bb0295241099294955",
-        "version" : "2.0.0"
+        "revision" : "6453030d6cfaab635823512ffcdeb220b4e7a7a1",
+        "version" : "2.1.0"
       }
     },
     {
@@ -41,8 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae",
-        "version" : "2.0.0"
+        "revision" : "be7fc8faaeb54affd996b60dbdcd6b000eaa002e",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "typescriptast",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/TypeScriptAST",
+      "state" : {
+        "revision" : "a6224e4764bf4bd1b7eee9aecf4e93722ceaf64c",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "be7fc8faaeb54affd996b60dbdcd6b000eaa002e",
-        "version" : "2.1.0"
+        "revision" : "72cf2f4ed97700aa9d719335cf2401b31250f746",
+        "version" : "2.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,14 +10,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.1.0")
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.1.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.0")
     ],
     targets: [
         .executableTarget(
             name: "Codegen",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "CodableToTypeScript", package: "CodableToTypeScript")
+                .product(name: "CodableToTypeScript", package: "CodableToTypeScript"),
+                .product(name: "SwiftTypeReader", package: "SwiftTypeReader")
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
             name: "Codegen",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "CodableToTypeScript", package: "CodableToTypeScript"),
-                .product(name: "SwiftTypeReader", package: "SwiftTypeReader")
+                "CodableToTypeScript",
+                "SwiftTypeReader"
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,16 +10,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.0.0"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.0.0"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.1.0")
     ],
     targets: [
         .executableTarget(
             name: "Codegen",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "CodableToTypeScript",
-                "SwiftTypeReader",
+                .product(name: "CodableToTypeScript", package: "CodableToTypeScript")
             ]
         ),
     ]

--- a/Sources/Codegen/GenerateTSClient.swift
+++ b/Sources/Codegen/GenerateTSClient.swift
@@ -15,7 +15,7 @@ extension GenericTypeDecl {
     }
 }
 
-struct SourceEntry {
+fileprivate struct SourceEntry {
     var file: String
     var source: TSSourceFile
 }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "be7fc8faaeb54affd996b60dbdcd6b000eaa002e",
-        "version" : "2.1.0"
+        "revision" : "72cf2f4ed97700aa9d719335cf2401b31250f746",
+        "version" : "2.1.1"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "f7c9c5ab09e54c2ff8bcd7bb0295241099294955",
-        "version" : "2.0.0"
+        "revision" : "6453030d6cfaab635823512ffcdeb220b4e7a7a1",
+        "version" : "2.1.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "f652300628eb2003449e627f1f394a27ea2af9a8",
-        "version" : "2.2.0"
+        "revision" : "71ae6adf89ba5346a209ec7f48dbb571a7e8ad1e",
+        "version" : "2.2.1"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "edfceecba13d68c1c993382806e72f7e96feaa86",
-        "version" : "2.44.0"
+        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
+        "version" : "2.45.0"
       }
     },
     {
@@ -194,8 +194,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "7be25045f38f90ceadda6230a61b620ad8035fae",
-        "version" : "2.0.0"
+        "revision" : "be7fc8faaeb54affd996b60dbdcd6b000eaa002e",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "typescriptast",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/TypeScriptAST",
+      "state" : {
+        "revision" : "a6224e4764bf4bd1b7eee9aecf4e93722ceaf64c",
+        "version" : "1.0.0"
       }
     },
     {

--- a/example/TSClient/src/Gen/common.gen.ts
+++ b/example/TSClient/src/Gen/common.gen.ts
@@ -1,3 +1,3 @@
 export interface IRawClient {
-  fetch(request: unknown, servicePath: string): Promise<unknown>
+    fetch(request: unknown, servicePath: string): Promise<unknown>;
 }


### PR DESCRIPTION
TypeScriptのコード生成用のライブラリを、
https://github.com/omochi/TypeScriptAST
として分離しました。

また、CodableToTypeScriptはそれを使うように切り替えました。

TypeScriptASTには、自動インポート文を生成するための仕組みを導入しました。
CallableKitが実装していたような、
どのファイルに何のシンボルが入っているか考慮して複数のimport文を生成する仕組みです。

これを利用する事で、CallableKit側のロジックを減らしました。

# TypeScript ASTの設計について

大きな設計方針は変わっていないですが、
TSCodeModuleから変化した部分を説明します。
その際に、SwiftTypeReaderの改修を通して感じた事を反映して改善しました。
https://github.com/omochi/CodableToTypeScript/pull/34

## enumからclass + protocolに変えた

enumだと、upcastにラップが必要なのと、caseドット式を多用するのがちょっと難しかったです。
クラスに変えた事で、普通にクラス名で init すれば、そのままupcastできるので、
ASTを組み立てるSwiftコードの記述がちょっとシンプルになりました。

クラスにしているのは、ASTツリーを書き換えるのが簡単だからです。
structの場合、部分書き換えのためにはルートから全体を変更する必要があって、
いろいろ扱いづらくなります。

SwiftTypeReaderでもdeclはASTツリーの一部であり、クラスにしていて、
同じ設計になっています。

## `export` は modifier として統一された。

TypeScriptのexportキーワードは、declに対する modifiers として統一されました。

```swift
TSTypeDecl(modifiers: [.export], ...)
TSFunctionDecl(modifiers: [.export, .async], ...)
```

これはenum化されているので `.export` と書きます。
また、asyncキーワードも同様にまとめました。

## いくらかenum化された

`const`, `let`, `var` とか、 `for` の `in`, `of` とかもenumになりました。

## BlockStmtの広い適用

クロージャの本体やクラスの本体など、ブレース `{ ... }` で包まれた中にコードを書くタイプの文法は、
全部 `BlockStmt` 型に寄せました。
これはもともと `elements` だった場合と比べると、
`BlockStmt` の `init` の分だけコードは膨らんでしまいますが、
文字列化する処理がシンプルになることや、
文法的に同じ形をしている事の意識付けが強まっています。

## いくつかの型の削除

`TSFunctionArgument` など、いくつかの型は削除して構造をシンプルにしました。
無くても各種実装において問題無さそうだったので。

## 略語の許容

SwiftTypeReaderで許容した略語を導入しました。
ident, params, args など。

## 新ノードの追加

`as` キャスト、代入文、`await` のためのノードを追加しました。
従来は infix operatorやprefix operatorで無理やり対応していました。

## TSIdentType, TSObjectType

従来は TSNamedTypeとTSRecordTypeがあったのですが、
これをTSIdentTypeとTSObjectTypeに変更しました。

これはTSIdentExprとTSObjectExprと対応がわかりやすいためです。

ドット式のためのTSMemberTypeとTSMemberExprなどもあります。

## custom expr

`TSCustomType` と `TSCustomExpr` として任意のコードをASTに注入できます。
もしライブラリが対応してないコードを生成したいときはこれでなんとかなります。
これらは `symbols` プロパティを持っているので、
カスタムコードの内部で参照しているシンボルをここに列挙することで、
依存抽出処理にも対応できます。

## テストコードの紹介

TypeScriptASTではかなりテストコードを書いているので、
`PrintDeclTests` と `PrintExprTests` を見れば、
どういうふうにASTを組めばよいかわかります。
https://github.com/omochi/TypeScriptAST/tree/main/Tests/TypeScriptASTTests
