### PR TITLE
CodableToTypeScriptをアップグレードする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "6453030d6cfaab635823512ffcdeb220b4e7a7a1",
-        "version" : "2.1.0"
+        "revision" : "adc03993975f0a784daeb6fbfb7e1b70dc8f7554",
+        "version" : "2.2.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "a6224e4764bf4bd1b7eee9aecf4e93722ceaf64c",
-        "version" : "1.0.0"
+        "revision" : "b846cf79f6e044c64d257823a9b5a1266114137a",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "adc03993975f0a784daeb6fbfb7e1b70dc8f7554",
-        "version" : "2.2.0"
+        "revision" : "f8e3beb9d3fed949b143735aac30023aac0acc7a",
+        "version" : "2.2.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "b846cf79f6e044c64d257823a9b5a1266114137a",
-        "version" : "1.1.0"
+        "revision" : "8e3016ef6570bddbc080798895c8465c725f842e",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.0"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.1"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.1.0"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.0")
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
     ],
     targets: [
         .executableTarget(

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "adc03993975f0a784daeb6fbfb7e1b70dc8f7554",
-        "version" : "2.2.0"
+        "revision" : "f8e3beb9d3fed949b143735aac30023aac0acc7a",
+        "version" : "2.2.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "b846cf79f6e044c64d257823a9b5a1266114137a",
-        "version" : "1.1.0"
+        "revision" : "8e3016ef6570bddbc080798895c8465c725f842e",
+        "version" : "1.1.1"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "6453030d6cfaab635823512ffcdeb220b4e7a7a1",
-        "version" : "2.1.0"
+        "revision" : "adc03993975f0a784daeb6fbfb7e1b70dc8f7554",
+        "version" : "2.2.0"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "a6224e4764bf4bd1b7eee9aecf4e93722ceaf64c",
-        "version" : "1.0.0"
+        "revision" : "b846cf79f6e044c64d257823a9b5a1266114137a",
+        "version" : "1.1.0"
       }
     },
     {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -1,8 +1,11 @@
 import { IRawClient } from "./common.gen.js";
 import {
     Array_decode,
+    Array_encode,
     OptionalField_decode,
+    OptionalField_encode,
     Optional_decode,
+    Optional_encode,
     identity
 } from "./decode.gen.js";
 
@@ -56,6 +59,12 @@ export type TestComplexType_K_JSON<T_JSON> = {
 export function TestComplexType_K_decode<T, T_JSON>(json: TestComplexType_K_JSON<T_JSON>, T_decode: (json: T_JSON) => T): TestComplexType_K<T> {
     return {
         x: T_decode(json.x)
+    };
+}
+
+export function TestComplexType_K_encode<T, T_JSON>(entity: TestComplexType_K<T>, T_encode: (entity: T) => T_JSON): TestComplexType_K_JSON<T_JSON> {
+    return {
+        x: T_encode(entity.x)
     };
 }
 
@@ -113,6 +122,38 @@ export function TestComplexType_E_decode<T, T_JSON>(json: TestComplexType_E_JSON
     }
 }
 
+export function TestComplexType_E_encode<T, T_JSON>(entity: TestComplexType_E<T>, T_encode: (entity: T) => T_JSON): TestComplexType_E_JSON<T_JSON> {
+    switch (entity.kind) {
+    case "k":
+        {
+            const e = entity.k;
+            return {
+                k: {
+                    _0: TestComplexType_K_encode(e._0, T_encode)
+                }
+            };
+        }
+    case "i":
+        {
+            const e = entity.i;
+            return {
+                i: {
+                    _0: e._0
+                }
+            };
+        }
+    case "n":
+        {
+            return {
+                n: {}
+            };
+        }
+    default:
+        const check: never = entity;
+        throw new Error("invalid case: " + check);
+    }
+}
+
 export type TestComplexType_L = {
     x: string;
 };
@@ -139,6 +180,20 @@ export function TestComplexType_Request_decode(json: TestComplexType_Request_JSO
     };
 }
 
+export function TestComplexType_Request_encode(entity: TestComplexType_Request): TestComplexType_Request_JSON {
+    return {
+        a: OptionalField_encode(entity.a, (entity: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>): TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]> => {
+            return TestComplexType_K_encode(entity, (entity: (TestComplexType_E<TestComplexType_L> | null)[]): (TestComplexType_E_JSON<TestComplexType_L> | null)[] => {
+                return Array_encode(entity, (entity: TestComplexType_E<TestComplexType_L> | null): TestComplexType_E_JSON<TestComplexType_L> | null => {
+                    return Optional_encode(entity, (entity: TestComplexType_E<TestComplexType_L>): TestComplexType_E_JSON<TestComplexType_L> => {
+                        return TestComplexType_E_encode(entity, identity);
+                    });
+                });
+            });
+        })
+    };
+}
+
 export type TestComplexType_Response = {
     a?: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>;
 };
@@ -154,6 +209,20 @@ export function TestComplexType_Response_decode(json: TestComplexType_Response_J
                 return Array_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
                     return Optional_decode(json, (json: TestComplexType_E_JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
                         return TestComplexType_E_decode(json, identity);
+                    });
+                });
+            });
+        })
+    };
+}
+
+export function TestComplexType_Response_encode(entity: TestComplexType_Response): TestComplexType_Response_JSON {
+    return {
+        a: OptionalField_encode(entity.a, (entity: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>): TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]> => {
+            return TestComplexType_K_encode(entity, (entity: (TestComplexType_E<TestComplexType_L> | null)[]): (TestComplexType_E_JSON<TestComplexType_L> | null)[] => {
+                return Array_encode(entity, (entity: TestComplexType_E<TestComplexType_L> | null): TestComplexType_E_JSON<TestComplexType_L> | null => {
+                    return Optional_encode(entity, (entity: TestComplexType_E<TestComplexType_L>): TestComplexType_E_JSON<TestComplexType_L> => {
+                        return TestComplexType_E_encode(entity, identity);
                     });
                 });
             });

--- a/example/TSClient/src/Gen/OtherDependency/CodableResult.gen.ts
+++ b/example/TSClient/src/Gen/OtherDependency/CodableResult.gen.ts
@@ -46,3 +46,34 @@ export function CodableResult_decode<
         throw new Error("unknown kind");
     }
 }
+
+export function CodableResult_encode<
+    T,
+    E,
+    T_JSON,
+    E_JSON
+>(entity: CodableResult<T, E>, T_encode: (entity: T) => T_JSON, E_encode: (entity: E) => E_JSON): CodableResult_JSON<T_JSON, E_JSON> {
+    switch (entity.kind) {
+    case "success":
+        {
+            const e = entity.success;
+            return {
+                success: {
+                    _0: T_encode(e._0)
+                }
+            };
+        }
+    case "failure":
+        {
+            const e = entity.failure;
+            return {
+                failure: {
+                    _0: E_encode(e._0)
+                }
+            };
+        }
+    default:
+        const check: never = entity;
+        throw new Error("invalid case: " + check);
+    }
+}

--- a/example/TSClient/src/Gen/SubmitError.gen.ts
+++ b/example/TSClient/src/Gen/SubmitError.gen.ts
@@ -1,4 +1,4 @@
-import { Array_decode } from "./decode.gen.js";
+import { Array_decode, Array_encode } from "./decode.gen.js";
 
 export type InputFieldError<E> = {
     name: E;
@@ -17,6 +17,13 @@ export function InputFieldError_decode<E, E_JSON>(json: InputFieldError_JSON<E_J
     };
 }
 
+export function InputFieldError_encode<E, E_JSON>(entity: InputFieldError<E>, E_encode: (entity: E) => E_JSON): InputFieldError_JSON<E_JSON> {
+    return {
+        name: E_encode(entity.name),
+        message: entity.message
+    };
+}
+
 export type SubmitError<E> = {
     errors: InputFieldError<E>[];
 };
@@ -29,6 +36,14 @@ export function SubmitError_decode<E, E_JSON>(json: SubmitError_JSON<E_JSON>, E_
     return {
         errors: Array_decode(json.errors, (json: InputFieldError_JSON<E_JSON>): InputFieldError<E> => {
             return InputFieldError_decode(json, E_decode);
+        })
+    };
+}
+
+export function SubmitError_encode<E, E_JSON>(entity: SubmitError<E>, E_encode: (entity: E) => E_JSON): SubmitError_JSON<E_JSON> {
+    return {
+        errors: Array_encode(entity.errors, (entity: InputFieldError<E>): InputFieldError_JSON<E_JSON> => {
+            return InputFieldError_encode(entity, E_encode);
         })
     };
 }

--- a/example/TSClient/src/Gen/decode.gen.ts
+++ b/example/TSClient/src/Gen/decode.gen.ts
@@ -2,26 +2,50 @@ export function identity<T>(json: T): T {
     return json;
 }
 
-export function OptionalField_decode<T, U>(json: T | undefined, T_decode: (json: T) => U): U | undefined {
+export function OptionalField_decode<T, T_JSON>(json: T_JSON | undefined, T_decode: (json: T_JSON) => T): T | undefined {
     if (json === undefined) return undefined;
     return T_decode(json);
 }
 
-export function Optional_decode<T, U>(json: T | null, T_decode: (json: T) => U): U | null {
+export function OptionalField_encode<T, T_JSON>(entity: T | undefined, T_encode: (entity: T) => T_JSON): T_JSON | undefined {
+    if (entity === undefined) return undefined;
+    return T_encode(entity);
+}
+
+export function Optional_decode<T, T_JSON>(json: T_JSON | null, T_decode: (json: T_JSON) => T): T | null {
     if (json === null) return null;
     return T_decode(json);
 }
 
-export function Array_decode<T, U>(json: T[], T_decode: (json: T) => U): U[] {
+export function Optional_encode<T, T_JSON>(entity: T | null, T_encode: (entity: T) => T_JSON): T_JSON | null {
+    if (entity === null) return null;
+    return T_encode(entity);
+}
+
+export function Array_decode<T, T_JSON>(json: T_JSON[], T_decode: (json: T_JSON) => T): T[] {
     return json.map(T_decode);
 }
 
-export function Dictionary_decode<T, U>(json: { [key: string]: T; }, T_decode: (json: T) => U): { [key: string]: U; } {
-    const result: { [key: string]: U; } = {};
+export function Array_encode<T, T_JSON>(entity: T[], T_encode: (entity: T) => T_JSON): T_JSON[] {
+    return entity.map(T_encode);
+}
+
+export function Dictionary_decode<T, T_JSON>(json: { [key: string]: T_JSON; }, T_decode: (json: T_JSON) => T): { [key: string]: T; } {
+    const entity: { [key: string]: T; } = {};
     for (const k in json) {
         if (json.hasOwnProperty(k)) {
-            result[k] = T_decode(json[k]);
+            entity[k] = T_decode(json[k]);
         }
     }
-    return result;
+    return entity;
+}
+
+export function Dictionary_encode<T, T_JSON>(entity: { [key: string]: T; }, T_encode: (entity: T) => T_JSON): { [key: string]: T_JSON; } {
+    const json: { [key: string]: T_JSON; } = {};
+    for (const k in entity) {
+        if (entity.hasOwnProperty(k)) {
+            json[k] = T_encode(entity[k]);
+        }
+    }
+    return json;
 }


### PR DESCRIPTION
CodableToTypeScriptが、エンコーダとカスタムタイプに対応しました。
その対応の過程で、設計とAPIの大きな改修を行いました。
API互換性が壊れたので追従のアップデートを書きました。

# アップデート内容について

TypeMapを強化して、デコーダ関数とエンコーダ関数の名前を登録できるようになりました。
例: https://github.com/omochi/CodableToTypeScript/blob/main/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeTests.swift#L30
これで、時刻情報を文字列で渡して、TS側で `Date` オブジェクトとして扱う、といったユースケースも対応できるはずです。

また、TypeMapだけではなく内部の設計として `TypeConverter` protocol を導入しました。
従来、C2TSは `CodeGenerator` の多くの関数が `SType` を引数に取っていて、
その関数内部で分岐をすることでコード生成を行っていました。

しかしこれは、型の種別についての分岐が各所に散らばってしまう問題がありました。
カスタムタイプやエンコーダの導入において、
これはコーディングを難しくするリスクがありました。

そこで、 それらの型の種別に応じた分岐をやめて、
型の種別が要求する振る舞いを `TypeConverter` protocol として定義しました。

`CodeGenerator` は `converter(for:)` メソッドによって、 
対応する `TypeConverter` を提供するだけの役割に縮小し、
各種生成処理は `TypeConverter` の APIに移し替えました。
`TypeConverter` が内部で別の型の情報を必要とするときは、
同様にその型の `TypeConverter` を取得するようにして動作します。

また、その `TypeConverter` を取得する部分にもフックできるようにして、
独自の `TypeConverter` も注入可能にしました。
これにより、全く異なるJSON化規則を導入する事なども可能となりました。

