### PR TITLE
Generate bundle friendly ts code

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "266eb8905198c1aa5563dee0bcf6de8249f232cf",
-        "version" : "2.2.2"
+        "revision" : "bbb4d2cfba391553b33bbf99d08b42d7528218ef",
+        "version" : "2.2.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "8e3016ef6570bddbc080798895c8465c725f842e",
-        "version" : "1.1.1"
+        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.2"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.3"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
     ],
     targets: [

--- a/Sources/Codegen/GenerateTSClient.swift
+++ b/Sources/Codegen/GenerateTSClient.swift
@@ -86,10 +86,7 @@ struct GenerateTSClient {
 
                 let fetchExpr: any TSExpr = TSCallExpr(
                     callee: TSMemberExpr(
-                        base: TSMemberExpr(
-                            base: TSIdentExpr.this,
-                            name: TSIdentExpr("rawClient")
-                        ),
+                        base: TSIdentExpr("raw"),
                         name: TSIdentExpr("fetch")
                     ),
                     args: [
@@ -138,38 +135,15 @@ struct GenerateTSClient {
                 )
             }
 
-            let clientClass = TSClassDecl(
-                name: "\(stype.serviceName)Client",
-                implements: [TSIdentType(clientInterface.name)],
-                body: TSBlockStmt([
-                    TSFieldDecl(
-                        name: "rawClient", type: TSIdentType("IRawClient")
-                    ),
-                    TSMethodDecl(
-                        name: "constructor",
-                        params: [.init(name: "rawClient", type: TSIdentType("IRawClient"))],
-                        result: nil,
-                        body: TSBlockStmt([
-                            TSAssignExpr(
-                                TSMemberExpr(base: TSIdentExpr.this, name: TSIdentExpr("rawClient")),
-                                TSIdentExpr("rawClient")
-                            )
-                        ])
-                    )
-                ] + functionsDecls)
-            )
-            codes.append(clientClass)
-
             codes.append(TSVarDecl(
                 modifiers: [.export],
                 kind: .const, name: "build\(stype.serviceName)Client",
                 initializer: TSClosureExpr(
                     params: [.init(name: "raw", type: TSIdentType("IRawClient"))],
                     result: TSIdentType(clientInterface.name),
-                    body: TSNewExpr(
-                        callee: TSIdentType("\(stype.serviceName)Client"),
-                        args: [TSIdentExpr("raw")]
-                    )
+                    body: TSBlockStmt([
+                        TSReturnStmt(TSObjectExpr(functionsDecls.map(TSObjectExpr.Field.method)))
+                    ])
                 )
             ))
         }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "266eb8905198c1aa5563dee0bcf6de8249f232cf",
-        "version" : "2.2.2"
+        "revision" : "bbb4d2cfba391553b33bbf99d08b42d7528218ef",
+        "version" : "2.2.3"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "8e3016ef6570bddbc080798895c8465c725f842e",
-        "version" : "1.1.1"
+        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
+        "version" : "1.2.0"
       }
     },
     {

--- a/example/TSClient/src/Gen/Account.gen.ts
+++ b/example/TSClient/src/Gen/Account.gen.ts
@@ -7,22 +7,16 @@ export interface IAccountClient {
     signin(request: AccountSignin_Request): Promise<CodableResult<AccountSignin_Response, SubmitError<AccountSignin_Error>>>;
 }
 
-class AccountClient implements IAccountClient {
-    rawClient: IRawClient;
-
-    constructor(rawClient: IRawClient) {
-        this.rawClient = rawClient;
-    }
-
-    async signin(request: AccountSignin_Request): Promise<CodableResult<AccountSignin_Response, SubmitError<AccountSignin_Error>>> {
-        const json = await this.rawClient.fetch(request, "Account/signin") as CodableResult_JSON<AccountSignin_Response, SubmitError_JSON<AccountSignin_Error>>;
-        return CodableResult_decode(json, identity, (json: SubmitError_JSON<AccountSignin_Error>): SubmitError<AccountSignin_Error> => {
-            return SubmitError_decode(json, identity);
-        });
-    }
-}
-
-export const buildAccountClient = (raw: IRawClient): IAccountClient => new AccountClient(raw);
+export const buildAccountClient = (raw: IRawClient): IAccountClient => {
+    return {
+        async signin(request: AccountSignin_Request): Promise<CodableResult<AccountSignin_Response, SubmitError<AccountSignin_Error>>> {
+            const json = await raw.fetch(request, "Account/signin") as CodableResult_JSON<AccountSignin_Response, SubmitError_JSON<AccountSignin_Error>>;
+            return CodableResult_decode(json, identity, (json: SubmitError_JSON<AccountSignin_Error>): SubmitError<AccountSignin_Error> => {
+                return SubmitError_decode(json, identity);
+            });
+        }
+    };
+};
 
 export type AccountSignin = never;
 

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -17,32 +17,23 @@ export interface IEchoClient {
     emptyRequestAndResponse(): Promise<void>;
 }
 
-class EchoClient implements IEchoClient {
-    rawClient: IRawClient;
-
-    constructor(rawClient: IRawClient) {
-        this.rawClient = rawClient;
-    }
-
-    async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
-        return await this.rawClient.fetch(request, "Echo/hello") as EchoHelloResponse;
-    }
-
-    async testTypicalEntity(request: User): Promise<User> {
-        return await this.rawClient.fetch(request, "Echo/testTypicalEntity") as User;
-    }
-
-    async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
-        const json = await this.rawClient.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
-        return TestComplexType_Response_decode(json);
-    }
-
-    async emptyRequestAndResponse(): Promise<void> {
-        return await this.rawClient.fetch({}, "Echo/emptyRequestAndResponse") as void;
-    }
-}
-
-export const buildEchoClient = (raw: IRawClient): IEchoClient => new EchoClient(raw);
+export const buildEchoClient = (raw: IRawClient): IEchoClient => {
+    return {
+        async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
+            return await raw.fetch(request, "Echo/hello") as EchoHelloResponse;
+        },
+        async testTypicalEntity(request: User): Promise<User> {
+            return await raw.fetch(request, "Echo/testTypicalEntity") as User;
+        },
+        async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
+            const json = await raw.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
+            return TestComplexType_Response_decode(json);
+        },
+        async emptyRequestAndResponse(): Promise<void> {
+            return await raw.fetch({}, "Echo/emptyRequestAndResponse") as void;
+        }
+    };
+};
 
 export type EchoHelloRequest = {
     name: string;


### PR DESCRIPTION
TSのコード生成において、各種XxxxClientクラスを作成しているのをやめて単なるオブジェクトにする。

クラス構文はwebpackなどにおけるminifyの効率が悪く、外部に露出が必要のないprivateなプロパティだろうとそのまま残ってしまう。
単なるオブジェクトにしてしまうのが効率が良さそうであったため、そうする。