### PR TITLE
C2TSのRawRepresentableサポートを利用する

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "3bf852b315ab6516c33adf6c34b917e82d63aec1",
-        "version" : "2.3.1"
+        "revision" : "5e53875215c59253cfdc29fdfdaa38aac26fd3de",
+        "version" : "2.3.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "bbb4d2cfba391553b33bbf99d08b42d7528218ef",
-        "version" : "2.2.3"
+        "revision" : "3bf852b315ab6516c33adf6c34b917e82d63aec1",
+        "version" : "2.3.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
-        "version" : "1.2.0"
+        "revision" : "509c3a20d5f8fe7584d4e9d67acc80690ff2fba0",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.3.1"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.3.2"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.2.3"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.3.1"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
     ],
     targets: [

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "bbb4d2cfba391553b33bbf99d08b42d7528218ef",
-        "version" : "2.2.3"
+        "revision" : "3bf852b315ab6516c33adf6c34b917e82d63aec1",
+        "version" : "2.3.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
-        "version" : "1.2.0"
+        "revision" : "509c3a20d5f8fe7584d4e9d67acc80690ff2fba0",
+        "version" : "1.3.0"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "3bf852b315ab6516c33adf6c34b917e82d63aec1",
-        "version" : "2.3.1"
+        "revision" : "5e53875215c59253cfdc29fdfdaa38aac26fd3de",
+        "version" : "2.3.2"
       }
     },
     {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -1,4 +1,4 @@
-import { User } from "./User.gen.js";
+import { User, User_JSON, User_decode } from "./User.gen.js";
 import { IRawClient } from "./common.gen.js";
 import {
     Array_decode,
@@ -12,7 +12,7 @@ import {
 
 export interface IEchoClient {
     hello(request: EchoHelloRequest): Promise<EchoHelloResponse>;
-    testTypicalEntity(request: User): Promise<User>;
+    testTypicalEntity(request: User_JSON): Promise<User>;
     testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response>;
     emptyRequestAndResponse(): Promise<void>;
 }
@@ -22,8 +22,9 @@ export const buildEchoClient = (raw: IRawClient): IEchoClient => {
         async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
             return await raw.fetch(request, "Echo/hello") as EchoHelloResponse;
         },
-        async testTypicalEntity(request: User): Promise<User> {
-            return await raw.fetch(request, "Echo/testTypicalEntity") as User;
+        async testTypicalEntity(request: User_JSON): Promise<User> {
+            const json = await raw.fetch(request, "Echo/testTypicalEntity") as User_JSON;
+            return User_decode(json);
         },
         async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
             const json = await raw.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON;

--- a/example/TSClient/src/Gen/User.gen.ts
+++ b/example/TSClient/src/Gen/User.gen.ts
@@ -3,6 +3,24 @@ export type User = {
     name: string;
 };
 
+export type User_JSON = {
+    id: User_ID_JSON;
+    name: string;
+};
+
+export function User_decode(json: User_JSON): User {
+    return {
+        id: User_ID_decode(json.id),
+        name: json.name
+    };
+}
+
 export type User_ID = string & {
     User_ID: never;
 };
+
+export type User_ID_JSON = string;
+
+export function User_ID_decode(json: User_ID_JSON): User_ID {
+    return json as User_ID;
+}

--- a/example/TSClient/src/Gen/User.gen.ts
+++ b/example/TSClient/src/Gen/User.gen.ts
@@ -1,4 +1,8 @@
 export type User = {
-    id: string;
+    id: User_ID;
     name: string;
+};
+
+export type User_ID = string & {
+    User_ID: never;
 };

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,5 +1,6 @@
 import { buildAccountClient } from "./Gen/Account.gen.js";
 import { buildEchoClient } from "./Gen/Echo.gen.js";
+import { User_ID } from "./Gen/User.gen.js";
 import { RawAPIClient } from "./raw_client.js";
 
 async function main() {
@@ -13,7 +14,7 @@ async function main() {
   }
 
   {
-    const res = await echoClient.testTypicalEntity({ id: "id", name: "name" });
+    const res = await echoClient.testTypicalEntity({ id: "id" as User_ID, name: "name" });
     console.log(JSON.stringify(res));
   }
   

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,6 +1,5 @@
 import { buildAccountClient } from "./Gen/Account.gen.js";
 import { buildEchoClient } from "./Gen/Echo.gen.js";
-import { User_ID } from "./Gen/User.gen.js";
 import { RawAPIClient } from "./raw_client.js";
 
 async function main() {
@@ -14,7 +13,7 @@ async function main() {
   }
 
   {
-    const res = await echoClient.testTypicalEntity({ id: "id" as User_ID, name: "name" });
+    const res = await echoClient.testTypicalEntity({ id: "id", name: "name" });
     console.log(JSON.stringify(res));
   }
   


### PR DESCRIPTION
C2TSにRawRepresentableサポートが入りました。
元の型はRawValueの型のファントムタイプとしてトランスパイルされます。

C2TSがRawRepresentable判定をする場合には、
ID suffixのtype mapを外します。

exampleにはシンプルなケースしか入っていませんが、
C2TS側ではいろいろ動作テストされています。
https://github.com/omochi/CodableToTypeScript/blob/2.3.1/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift#L300