### PR TITLE
Add Date coding support & use entity type for TS request

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "5e53875215c59253cfdc29fdfdaa38aac26fd3de",
-        "version" : "2.3.2"
+        "revision" : "6dc317a1ab7e7aa52de8051454b5ac2781b886c3",
+        "version" : "2.3.4"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "72cf2f4ed97700aa9d719335cf2401b31250f746",
-        "version" : "2.1.1"
+        "revision" : "be01de25a21002d3d42532bfc5069a2b994a90a0",
+        "version" : "2.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.3.2"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1")
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.3.4"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.2")
     ],
     targets: [
         .executableTarget(

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -80,7 +80,7 @@ struct GenerateTSClient {
 
                 let reqExpr: any TSExpr
                 if let sReq = f.request?.raw,
-                   try generator.converter(for: sReq).hasJSONType() {
+                   try generator.converter(for: sReq).hasEncode() {
                     let encodeExpr = try generator.converter(for: sReq).callEncode(entity: TSIdentExpr(f.request!.argName))
                     reqExpr = encodeExpr
                 } else {
@@ -100,7 +100,7 @@ struct GenerateTSClient {
 
                 let blockBody: [any ASTNode]
                 if let sRes = f.response?.raw,
-                   try generator.converter(for: sRes).hasJSONType()
+                   try generator.converter(for: sRes).hasDecode()
                 {
                     let jsonTsType = try generator.converter(for: sRes).type(for: .json)
                     let decodeExpr = try generator.converter(for: sRes).callDecode(json: TSIdentExpr("json"))

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "5e53875215c59253cfdc29fdfdaa38aac26fd3de",
-        "version" : "2.3.2"
+        "revision" : "6dc317a1ab7e7aa52de8051454b5ac2781b886c3",
+        "version" : "2.3.4"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "72cf2f4ed97700aa9d719335cf2401b31250f746",
-        "version" : "2.1.1"
+        "revision" : "be01de25a21002d3d42532bfc5069a2b994a90a0",
+        "version" : "2.1.2"
       }
     },
     {

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -3,6 +3,8 @@ import Foundation
 public protocol EchoServiceProtocol {
     func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse
 
+    func tommorow(now: Date) async throws -> Date
+
     func testTypicalEntity(request: User) async throws -> User
 
     func testComplexType(request: TestComplexType.Request) async throws -> TestComplexType.Response

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -10,6 +10,9 @@ public struct EchoServiceStub<C: StubClientProtocol>: EchoServiceProtocol, Senda
     public func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse {
         return try await client.send(path: "Echo/hello", request: request)
     }
+    public func tommorow(now: Date) async throws -> Date {
+        return try await client.send(path: "Echo/tommorow", request: now)
+    }
     public func testTypicalEntity(request: User) async throws -> User {
         return try await client.send(path: "Echo/testTypicalEntity", request: request)
     }

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -10,6 +10,11 @@ import Foundation
         }
 
         do {
+            let res = try await client.echo.tommorow(now: Date())
+            print(res)
+        }
+
+        do {
             let res = try await client.echo.testTypicalEntity(request: .init(id: .init(rawValue: "id"), name: "name"))
             dump(res)
         }

--- a/example/Sources/Server/Gen/Echo.gen.swift
+++ b/example/Sources/Server/Gen/Echo.gen.swift
@@ -12,6 +12,7 @@ struct EchoServiceProvider<Bridge: VaporToServiceBridgeProtocol, Service: EchoSe
     func boot(routes: RoutesBuilder) throws {
         routes.group("Echo") { group in
             group.post("hello", use: bridge.makeHandler(serviceBuilder, { $0.hello }))
+            group.post("tommorow", use: bridge.makeHandler(serviceBuilder, { $0.tommorow }))
             group.post("testTypicalEntity", use: bridge.makeHandler(serviceBuilder, { $0.testTypicalEntity }))
             group.post("testComplexType", use: bridge.makeHandler(serviceBuilder, { $0.testComplexType }))
             group.post("emptyRequestAndResponse", use: bridge.makeHandler(serviceBuilder, { $0.emptyRequestAndResponse }))

--- a/example/Sources/Server/main.swift
+++ b/example/Sources/Server/main.swift
@@ -4,6 +4,8 @@ import Service
 let app = Application()
 defer { app.shutdown() }
 
+app.logger.logLevel = .error
+
 let echoProvider = EchoServiceProvider(bridge: .default) { req in
     makeEchoService()
 }

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -1,4 +1,5 @@
 import APIDefinition
+import Foundation
 
 public func makeEchoService() -> some EchoServiceProtocol {
     EchoService()
@@ -9,6 +10,10 @@ struct EchoService: EchoServiceProtocol {
         .init(
             message: "Hello, \(request.name)!"
         )
+    }
+
+    func tommorow(now: Date) async throws -> Date {
+        now.addingTimeInterval(60 * 60 * 24 * 1)
     }
 
     func testTypicalEntity(request: User) async throws -> User {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -31,7 +31,7 @@ export const buildEchoClient = (raw: IRawClient): IEchoClient => {
             return Date_decode(json);
         },
         async testTypicalEntity(request: User): Promise<User> {
-            const json = await raw.fetch(request as User_JSON, "Echo/testTypicalEntity") as User_JSON;
+            const json = await raw.fetch(request, "Echo/testTypicalEntity") as User_JSON;
             return User_decode(json);
         },
         async testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response> {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -3,7 +3,6 @@ import { IRawClient } from "./common.gen.js";
 import {
     Array_decode,
     Array_encode,
-    Date_JSON,
     Date_decode,
     Date_encode,
     OptionalField_decode,
@@ -27,7 +26,7 @@ export const buildEchoClient = (raw: IRawClient): IEchoClient => {
             return await raw.fetch(request, "Echo/hello") as EchoHelloResponse;
         },
         async tommorow(now: Date): Promise<Date> {
-            const json = await raw.fetch(Date_encode(now), "Echo/tommorow") as Date_JSON;
+            const json = await raw.fetch(Date_encode(now), "Echo/tommorow") as string;
             return Date_decode(json);
         },
         async testTypicalEntity(request: User): Promise<User> {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -3,6 +3,8 @@ import { IRawClient } from "./common.gen.js";
 import {
     Array_decode,
     Array_encode,
+    Date_decode,
+    Date_encode,
     OptionalField_decode,
     OptionalField_encode,
     Optional_decode,
@@ -12,8 +14,9 @@ import {
 
 export interface IEchoClient {
     hello(request: EchoHelloRequest): Promise<EchoHelloResponse>;
+    tommorow(now: Date): Promise<Date>;
     testTypicalEntity(request: User): Promise<User>;
-    testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response>;
+    testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response>;
     emptyRequestAndResponse(): Promise<void>;
 }
 
@@ -22,11 +25,15 @@ export const buildEchoClient = (raw: IRawClient): IEchoClient => {
         async hello(request: EchoHelloRequest): Promise<EchoHelloResponse> {
             return await raw.fetch(request, "Echo/hello") as EchoHelloResponse;
         },
+        async tommorow(now: Date): Promise<Date> {
+            const json = await raw.fetch(Date_encode(now), "Echo/tommorow") as string;
+            return Date_decode(json);
+        },
         async testTypicalEntity(request: User): Promise<User> {
             return await raw.fetch(request, "Echo/testTypicalEntity") as User;
         },
-        async testComplexType(request: TestComplexType_Request_JSON): Promise<TestComplexType_Response> {
-            const json = await raw.fetch(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
+        async testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response> {
+            const json = await raw.fetch(TestComplexType_Request_encode(request), "Echo/testComplexType") as TestComplexType_Response_JSON;
             return TestComplexType_Response_decode(json);
         },
         async emptyRequestAndResponse(): Promise<void> {

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -3,6 +3,7 @@ import { IRawClient } from "./common.gen.js";
 import {
     Array_decode,
     Array_encode,
+    Date_JSON,
     Date_decode,
     Date_encode,
     OptionalField_decode,
@@ -26,7 +27,7 @@ export const buildEchoClient = (raw: IRawClient): IEchoClient => {
             return await raw.fetch(request, "Echo/hello") as EchoHelloResponse;
         },
         async tommorow(now: Date): Promise<Date> {
-            const json = await raw.fetch(Date_encode(now), "Echo/tommorow") as string;
+            const json = await raw.fetch(Date_encode(now), "Echo/tommorow") as Date_JSON;
             return Date_decode(json);
         },
         async testTypicalEntity(request: User): Promise<User> {

--- a/example/TSClient/src/Gen/decode.gen.ts
+++ b/example/TSClient/src/Gen/decode.gen.ts
@@ -49,3 +49,11 @@ export function Dictionary_encode<T, T_JSON>(entity: { [key: string]: T; }, T_en
     }
     return json;
 }
+
+export function Date_encode(d: Date) {
+    return d.toISOString();
+}
+
+export function Date_decode(iso: string) {
+    return new Date(iso);
+}

--- a/example/TSClient/src/Gen/decode.gen.ts
+++ b/example/TSClient/src/Gen/decode.gen.ts
@@ -54,6 +54,8 @@ export function Date_encode(d: Date) {
     return d.toISOString();
 }
 
-export function Date_decode(iso: string) {
+export function Date_decode(iso: Date_JSON) {
     return new Date(iso);
 }
+
+export type Date_JSON = string;

--- a/example/TSClient/src/Gen/decode.gen.ts
+++ b/example/TSClient/src/Gen/decode.gen.ts
@@ -54,8 +54,6 @@ export function Date_encode(d: Date) {
     return d.toISOString();
 }
 
-export function Date_decode(iso: Date_JSON) {
+export function Date_decode(iso: string) {
     return new Date(iso);
 }
-
-export type Date_JSON = string;

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,5 +1,6 @@
 import { buildAccountClient } from "./Gen/Account.gen.js";
 import { buildEchoClient } from "./Gen/Echo.gen.js";
+import { User_ID } from "./Gen/User.gen.js";
 import { RawAPIClient } from "./raw_client.js";
 
 async function main() {
@@ -18,7 +19,8 @@ async function main() {
   }
 
   {
-    const res = await echoClient.testTypicalEntity({ id: "id", name: "name" });
+    const id = "id" as User_ID
+    const res = await echoClient.testTypicalEntity({ id, name: "name" });
     console.log(JSON.stringify(res));
   }
   

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -13,6 +13,11 @@ async function main() {
   }
 
   {
+    const res = await echoClient.tommorow(new Date());
+    console.log(res);
+  }
+
+  {
     const res = await echoClient.testTypicalEntity({ id: "id", name: "name" });
     console.log(JSON.stringify(res));
   }
@@ -21,9 +26,9 @@ async function main() {
     const res = await echoClient.testComplexType({
       a: {
         x: [
-          { k: { _0: { x: { x: "hello" } } } },
-          { i: { _0: 100 } },
-          { n: {} },
+          { kind: "k", k: { _0: { x: { x: "hello" } } } },
+          { kind: "i", i: { _0: 100 } },
+          { kind: "n", n: {} },
           null
         ]
       }

--- a/example/test.sh
+++ b/example/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -uex
+#!/bin/bash -ue
 set -o pipefail
 
 if [ "$(uname)" == 'Darwin' ]; then


### PR DESCRIPTION
C2TSのカスタムコーディング機能とencoderサポートを利用して、Swiftの`Date`をJSの`Date`に変換する作業をCallableKitの内部で行う。
同時に、これまでTSからSwift関数を呼ぶ際はリクエストの型がJSON型であった部分を、Entity型になるように変更する。
これにより通信時のJSON表現は完全にCallableKitの内部に隠蔽される。