### PR TITLE
TypeAliasのサポート

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "17206ceab6c2371e9c46fb2046b633709953698a",
-        "version" : "2.4.0"
+        "revision" : "d77e58c5750daff29f3302854edcece462578892",
+        "version" : "2.5.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "1625fa6a7f021acc0b1eb54cd4f24ea9838523cf",
-        "version" : "2.2.0"
+        "revision" : "f31096036ec85e1087d957dd881c187a1628c3f7",
+        "version" : "2.3.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "509c3a20d5f8fe7584d4e9d67acc80690ff2fba0",
-        "version" : "1.3.0"
+        "revision" : "1549aa2d5cf62024c0d7bb165ae14e7e6ca5a232",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.4.1"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.2")
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.5.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.3.1")
     ],
     targets: [
         .executableTarget(

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -237,7 +237,7 @@ struct GenerateTSClient {
                         || stype is EnumDecl
                         || stype is TypeAliasDecl
                 else {
-                    return false
+                    return true
                 }
 
                 let converter = try generator.converter(for: stype.declaredInterfaceType)

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -229,14 +229,17 @@ struct GenerateTSClient {
         }
 
         // Request・Response型定義の出力
+
         for stype in file.types {
-            guard stype is StructDecl
-                    || stype is EnumDecl
-            else {
-                continue
-            }
             // 型定義とjson変換関数だけを抜き出し
-            try stype.walk { (stype) in
+            try stype.walkTypeDecls { (stype) in
+                guard stype is StructDecl
+                        || stype is EnumDecl
+                        || stype is TypeAliasDecl
+                else {
+                    return false
+                }
+
                 let converter = try generator.converter(for: stype.declaredInterfaceType)
                 codes += try converter.ownDecls().decls
                 return true

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "134c7dc45e372d88b07db300ec37f4d71c0b9bea",
-        "version" : "2.4.1"
+        "revision" : "d77e58c5750daff29f3302854edcece462578892",
+        "version" : "2.5.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "1625fa6a7f021acc0b1eb54cd4f24ea9838523cf",
-        "version" : "2.2.0"
+        "revision" : "f31096036ec85e1087d957dd881c187a1628c3f7",
+        "version" : "2.3.1"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "0dbbd10881e36afe5ca731b3e83f0c31c7f7941e",
-        "version" : "1.4.1"
+        "revision" : "1549aa2d5cf62024c0d7bb165ae14e7e6ca5a232",
+        "version" : "1.5.2"
       }
     },
     {

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -10,6 +10,8 @@ public protocol EchoServiceProtocol {
     func testComplexType(request: TestComplexType.Request) async throws -> TestComplexType.Response
 
     func emptyRequestAndResponse() async throws
+
+    func testTypeAliasToRawRepr(request: Student) async throws -> Student
 }
 
 public struct EchoHelloRequest: Codable, Sendable {

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -1,0 +1,7 @@
+public struct GenericIDz<T>: Codable & RawRepresentable {
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var rawValue: String
+}

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -1,0 +1,14 @@
+public struct Student: Codable {
+    public typealias IDz = GenericIDz<Student>
+
+    public init(
+        id: IDz,
+        name: String
+    ) {
+        self.id = id
+        self.name = name
+    }
+
+    public var id: IDz
+    public var name: String
+}

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -22,6 +22,9 @@ public struct EchoServiceStub<C: StubClientProtocol>: EchoServiceProtocol, Senda
     public func emptyRequestAndResponse() async throws {
         return try await client.send(path: "Echo/emptyRequestAndResponse")
     }
+    public func testTypeAliasToRawRepr(request: Student) async throws -> Student {
+        return try await client.send(path: "Echo/testTypeAliasToRawRepr", request: request)
+    }
 }
 
 extension StubClientProtocol {

--- a/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
+++ b/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
@@ -104,7 +104,7 @@ private class TaskBox: @unchecked Sendable {
 extension URLSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let taskBox = TaskBox()
-        try await withTaskCancellationHandler(operation: {
+        return try await withTaskCancellationHandler(operation: {
             try await withCheckedThrowingContinuation { continuation in
                 let task = dataTask(with: request) { data, response, error in
                     guard let data, let response else {

--- a/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
+++ b/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
@@ -104,7 +104,7 @@ private class TaskBox: @unchecked Sendable {
 extension URLSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let taskBox = TaskBox()
-        return try await withTaskCancellationHandler(operation: {
+        try await withTaskCancellationHandler(operation: {
             try await withCheckedThrowingContinuation { continuation in
                 let task = dataTask(with: request) { data, response, error in
                     guard let data, let response else {

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import APIDefinition
 
 struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
     var errorMessage: String
@@ -46,6 +47,15 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
 
         do {
             try await client.echo.emptyRequestAndResponse()
+        }
+
+        do {
+            let student: Student = .init(
+                id: Student.IDz(rawValue: "0001"),
+                name: "taro"
+            )
+            let res = try await client.echo.testTypeAliasToRawRepr(request: student)
+            dump(res)
         }
 
         do {

--- a/example/Sources/Server/Gen/Echo.gen.swift
+++ b/example/Sources/Server/Gen/Echo.gen.swift
@@ -16,6 +16,7 @@ struct EchoServiceProvider<Bridge: VaporToServiceBridgeProtocol, Service: EchoSe
             group.post("testTypicalEntity", use: bridge.makeHandler(serviceBuilder, { $0.testTypicalEntity }))
             group.post("testComplexType", use: bridge.makeHandler(serviceBuilder, { $0.testComplexType }))
             group.post("emptyRequestAndResponse", use: bridge.makeHandler(serviceBuilder, { $0.emptyRequestAndResponse }))
+            group.post("testTypeAliasToRawRepr", use: bridge.makeHandler(serviceBuilder, { $0.testTypeAliasToRawRepr }))
         }
     }
 }

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -26,4 +26,8 @@ struct EchoService: EchoServiceProtocol {
 
     func emptyRequestAndResponse() async throws {
     }
+
+    func testTypeAliasToRawRepr(request: Student) async throws -> Student {
+        return request
+    }
 }

--- a/example/TSClient/src/Gen/Echo.gen.ts
+++ b/example/TSClient/src/Gen/Echo.gen.ts
@@ -1,3 +1,4 @@
+import { Student, Student_JSON, Student_decode } from "./Student.gen.js";
 import { User, User_JSON, User_decode } from "./User.gen.js";
 import { IStubClient } from "./common.gen.js";
 import {
@@ -15,6 +16,7 @@ export interface IEchoClient {
     testTypicalEntity(request: User): Promise<User>;
     testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response>;
     emptyRequestAndResponse(): Promise<void>;
+    testTypeAliasToRawRepr(request: Student): Promise<Student>;
 }
 
 export const bindEcho = (stub: IStubClient): IEchoClient => {
@@ -36,6 +38,10 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
         },
         async emptyRequestAndResponse(): Promise<void> {
             return await stub.send({}, "Echo/emptyRequestAndResponse") as void;
+        },
+        async testTypeAliasToRawRepr(request: Student): Promise<Student> {
+            const json = await stub.send(request, "Echo/testTypeAliasToRawRepr") as Student_JSON;
+            return Student_decode(json);
         }
     };
 };

--- a/example/TSClient/src/Gen/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/GenericID.gen.ts
@@ -1,0 +1,9 @@
+export type GenericIDz<T> = string & {
+    GenericIDz: never;
+};
+
+export type GenericIDz_JSON<T_JSON> = string;
+
+export function GenericIDz_decode<T, T_JSON>(json: GenericIDz_JSON<T_JSON>, T_decode: (json: T_JSON) => T): GenericIDz<T> {
+    return json as GenericIDz<T>;
+}

--- a/example/TSClient/src/Gen/Student.gen.ts
+++ b/example/TSClient/src/Gen/Student.gen.ts
@@ -1,0 +1,26 @@
+import { GenericIDz, GenericIDz_JSON, GenericIDz_decode } from "./GenericID.gen.js";
+
+export type Student = {
+    id: Student_IDz;
+    name: string;
+};
+
+export type Student_JSON = {
+    id: Student_IDz_JSON;
+    name: string;
+};
+
+export function Student_decode(json: Student_JSON): Student {
+    return {
+        id: Student_IDz_decode(json.id),
+        name: json.name
+    };
+}
+
+export type Student_IDz = GenericIDz<Student>;
+
+export type Student_IDz_JSON = GenericIDz_JSON<Student_JSON>;
+
+export function Student_IDz_decode(json: Student_IDz_JSON): Student_IDz {
+    return GenericIDz_decode(json, Student_decode);
+}

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -2,6 +2,7 @@ import { bindAccount } from "./Gen/Account.gen.js";
 import { bindEcho } from "./Gen/Echo.gen.js";
 import { User_ID } from "./Gen/User.gen.js";
 import { createStubClient } from "./Gen/common.gen.js";
+import { Student, Student_IDz } from "./Gen/Student.gen.js";
 
 async function main() {
   const stub = createStubClient("http://127.0.0.1:8080");
@@ -40,6 +41,15 @@ async function main() {
 
   {
     await echoClient.emptyRequestAndResponse();
+  }
+
+  {
+    const student: Student = {
+      id: "0001" as Student_IDz,
+      name: "taro"
+    }
+    const res = await echoClient.testTypeAliasToRawRepr(student);
+    console.log(JSON.stringify(res));
   }
 
   {


### PR DESCRIPTION
C2TSのTypeAliasサポートに追従します。

exampleに利用例の `Student` を追加しました。
組み込みの `*ID` に対するtypemapが発動しないように、 `*IDz` という型名にしました。