### PR TITLE
Swiftクライアント生成器のバグを修正する

### DIFF
--- a/Sources/CallableKit/GenerateSwiftClient.swift
+++ b/Sources/CallableKit/GenerateSwiftClient.swift
@@ -170,7 +170,7 @@ private class TaskBox: @unchecked Sendable {
 extension URLSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let taskBox = TaskBox()
-        try await withTaskCancellationHandler(operation: {
+        return try await withTaskCancellationHandler(operation: {
             try await withCheckedThrowingContinuation { continuation in
                 let task = dataTask(with: request) { data, response, error in
                     guard let data, let response else {


### PR DESCRIPTION
`return` がすっぽ抜けてコンパイルできなくなっていました。
生成物がコミットされていないため、CIで見逃されていたようです。