### PR TITLE
Generator.OutputSinkの内部でフルパスを使う

### DIFF
--- a/Sources/CallableKit/Generator.swift
+++ b/Sources/CallableKit/Generator.swift
@@ -23,7 +23,7 @@ struct Generator {
 
     class OutputSink {
         public init(dstDirectory: URL, fileManager: FileManager) {
-            self.dstDirectory = dstDirectory.absoluteURL
+            self.dstDirectory = dstDirectory.absoluteURL.standardized
             self.fileManager = fileManager
         }
 


### PR DESCRIPTION
以下のレビューにおいて、相対パスを `String` で扱っている事に難しさがありそうでした。
https://github.com/sidepelican/CallableKit/pull/26/files#r1064008640

そこで `Generator.OutputSink` の内部では `URL` を扱うように変更します。

`Generator.OutputFile` と `Generator.OutputSink.callAsFunction` のインターフェースは変更していないので、
ユーザー側においてはファイル名で扱うところは変わっていません。

そのファイル名を `URL` に変換する処理を、
`Generator.OutputSink.path(name:)` に統一し、
そこで表現の正規化を行うようにしました。

これにより、 `OutputFile.name` が `.` や `..` を含む場合でも、
正しく同一パスの判定ができるようになりました。

---

ところで、これを更に発展させて、
ユーザー側のインターフェースにおいても、
`URL` で指定できるようにする事を検討しましたが、
以下の問題点があったので見送りました。

1. `dstDirectory` の外のパスへの出力が可能になってしまう。
  現状のAPIは、`dstDirectory` 以下の部分パスを渡す形式になっているので、
  そのディレクトリの外を指定する事が静的に防止できている。
  しかし、`URL` は任意のパスを表現できるのでその点の安全性が低下してしまう。
  動的な検査は可能だが、静的な制約よりは機能低下してしまう。

2. メッセージ出力において、
  ```
  generated... APIDefinition/Echo.gen.ts
  ```
  のように `dstDirectory` 以下の部分を出力するが、
  `URL` で扱うとこれの実装が難しい。
  任意の `URL` に対して `dstDirectory` からの相対パスを解かねばならないが、
  これは `Foundation` では提供されていないので `CallableKit` にとってはやや過剰な変更かもしれない。

---

以下は相談です。

1 については明確に劣化なのですがまずこれは諦めるしかありません。
ただ、 2 についてはやってもいいかもと思っています。

まず相対パスの解決については、
すでに `TypeScriptAST` が `extension URL.relative(from:)` を提供しています。

そして、 `GenerateTSClient` においては、
`CodableToTypeScript.PackageGenerator` が `PackageEntry` としてフルパスの `URL` を返す都合上、
上記のAPIを利用して、ユーザー側でフルパスから相対パスを解く事を既にやっています。

このようなユーザー側が使うライブラリの都合でフルパスが出てきてしまう事は状況として他にもありえそうですし、
ユーザー側も `URL` で扱ったほうが、 `appendingPathComponent` などがあるのでStringよりはパス操作がしやすいです。

どうせユーザー側で相対パスを解く複雑さが生じるのであれば、
それをライブラリであるGenerator側に押し込める事で、
ユーザー側から `URL` をそのまま渡す事を許容すると、使いやすくなりそうです。

---

余談ですが、現状もこのパッチでも、
ファイル名として `..` を多く含むファイル名を使用することで、
`dstDirectory` 外にアクセスする事ができてしまいそうです。
そういう意味では `String` になっている安全性は結局不完全で、
動的な保護が必要と言えそうです。

`URL` 対応を行うところで `dstDirectory` 配下判定を実装すれば、
この穴が一緒に防げそうです。
