### PR TITLE
Flatten rawrepresentable

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "rawrepresentable",
-        "revision" : "1bb7474e3a3b0a5aa119cc0c8c6c5abc216f3d85"
+        "revision" : "d0163e47c80bbab53dbbebf1d750166c430401c5",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "8c6c49a70eb3492e11393c16103156a0b9f66e09",
-        "version" : "2.6.0"
+        "branch" : "composition_type",
+        "revision" : "21565f88e5c528c06eccd96ea677f09e200e6034"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "5015235b2cd2143a4cec22fb5d79cfbd8a5c58a5",
-        "version" : "2.8.2"
+        "branch" : "rawrepresentable",
+        "revision" : "1bb7474e3a3b0a5aa119cc0c8c6c5abc216f3d85"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "composition_type",
-        "revision" : "21565f88e5c528c06eccd96ea677f09e200e6034"
+        "revision" : "18ee757dbb9aac67fdbb71545e8c246f4248cbb0",
+        "version" : "2.6.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.8.2"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "composition_type"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.2"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.8.2"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "rawrepresentable"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.2"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.8.2"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "composition_type"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", branch: "rawrepresentable"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.9.0"),
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.2"),
     ],
     targets: [

--- a/Sources/CallableKit/GenerateTS/GenerateTS+commonlib.swift
+++ b/Sources/CallableKit/GenerateTS/GenerateTS+commonlib.swift
@@ -1,0 +1,126 @@
+import Foundation
+import TypeScriptAST
+
+extension GenerateTSClient {
+    func generateCommon() -> TSSourceFile {
+        let string = TSIdentType.string
+        var elements: [any ASTNode] = [
+            TSInterfaceDecl(modifiers: [.export], name: "IStubClient", body: TSBlockStmt([
+                TSMethodDecl(
+                    name: "send", params: [
+                        .init(name: "request", type: TSIdentType.unknown),
+                        .init(name: "servicePath", type: TSIdentType.string)
+                    ],
+                    result: TSIdentType.promise(TSIdentType.unknown)
+                )
+            ])),
+            TSTypeDecl(modifiers: [.export], name: "Headers", type: TSIdentType("Record", genericArgs: [string, string])),
+            TSTypeDecl(modifiers: [.export], name: "StubClientOptions", type: TSObjectType([
+                .field(TSFieldDecl(name: "headers", isOptional: true, type: TSFunctionType(params: [], result: TSUnionType([
+                    TSIdentType("Headers"),
+                    TSIdentType("Promise", genericArgs: [TSIdentType("Headers")]),
+                ])))),
+                .field(TSFieldDecl(name: "mapResponseError", isOptional: true, type: TSFunctionType(params: [.init(name: "e", type: TSIdentType("FetchHTTPStubResponseError"))], result: TSIdentType.error))),
+            ])),
+            TSClassDecl(modifiers: [.export], name: "FetchHTTPStubResponseError", extends: TSIdentType("Error"), body: TSBlockStmt([
+                TSFieldDecl(modifiers: [.readonly], name: "path", type: string),
+                TSFieldDecl(modifiers: [.readonly], name: "response", type: TSIdentType("Response")),
+                TSMethodDecl(name: "constructor", params: [.init(name: "path", type: string), .init(name: "response", type: TSIdentType("Response"))], body: TSBlockStmt([
+                    TSCallExpr(callee: TSIdentExpr("super"), args: [TSTemplateLiteralExpr("ResponseError. path=\(ident: "path"), status=\(TSMemberExpr(base: TSIdentExpr("response"), name: "status"))")]),
+                    TSAssignExpr(TSMemberExpr(base: TSIdentExpr.this, name: "path"), TSIdentExpr("path")),
+                    TSAssignExpr(TSMemberExpr(base: TSIdentExpr.this, name: "response"), TSIdentExpr("response")),
+                ])),
+            ])),
+            TSVarDecl(
+                modifiers: [.export],
+                kind: .const,
+                name: "createStubClient",
+                initializer: TSClosureExpr(
+                    params: [
+                        .init(name: "baseURL", type: string),
+                        .init(name: "options", isOptional: true, type: TSIdentType("StubClientOptions")),
+                    ],
+                    result: TSIdentType("IStubClient"),
+                    body: TSBlockStmt([
+                        TSReturnStmt(TSObjectExpr([
+                            .method(TSMethodDecl(modifiers: [.async], name: "send", params: [.init(name: "request"), .init(name: "servicePath")], body: TSBlockStmt([
+                                TSVarDecl(kind: .let, name: "optionHeaders", type: TSIdentType("Headers"), initializer: TSObjectExpr([])),
+                                TSIfStmt(condition: TSMemberExpr(base: TSIdentExpr("options"), isOptional: true, name: "headers"), then: TSBlockStmt([
+                                    TSAssignExpr(
+                                        TSIdentExpr("optionHeaders"),
+                                        TSAwaitExpr(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("options"), name: "headers"), args: []))
+                                    ),
+                                ])),
+
+                                TSVarDecl(kind: .const, name: "res", initializer: TSAwaitExpr(TSCallExpr(callee: TSIdentExpr("fetch"), args: [
+                                    TSCallExpr(callee: TSMemberExpr(
+                                        base: TSNewExpr(callee: TSIdentType("URL"), args: [
+                                            TSIdentExpr("servicePath"),
+                                            TSIdentExpr("baseURL"),
+                                        ]),
+                                        name: "toString"
+                                    ), args: []),
+                                    TSObjectExpr([
+                                        .named(name: "method", value: TSStringLiteralExpr("POST")),
+                                        .named(name: "headers", value: TSObjectExpr([
+                                            .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
+                                            .destructuring(value: TSIdentExpr("optionHeaders")),
+                                        ])),
+                                        .named(name: "body", value: TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("JSON"), name: "stringify"), args: [TSIdentExpr("request")])),
+                                    ]),
+                                ]))),
+                                TSIfStmt(condition: TSPrefixOperatorExpr("!", TSMemberExpr(base: TSIdentExpr("res"), name: "ok")), then: TSBlockStmt([
+                                    TSVarDecl(kind: .const, name: "e", initializer: TSNewExpr(callee: TSIdentType("FetchHTTPStubResponseError"), args: [
+                                        TSIdentExpr("servicePath"),
+                                        TSIdentExpr("res"),
+                                    ])),
+                                    TSIfStmt(
+                                        condition: TSMemberExpr(base: TSIdentExpr("options"), isOptional: true, name: "mapResponseError"),
+                                        then: TSBlockStmt([
+                                            TSThrowStmt(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("options"), name: "mapResponseError"), args: [TSIdentExpr("e")])),
+                                        ]),
+                                        else: TSBlockStmt([
+                                            TSThrowStmt(TSIdentExpr("e")),
+                                        ])
+                                    ),
+                                ])),
+                                TSReturnStmt(TSAwaitExpr(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("res"), name: "json"), args: []))),
+                            ])))
+                        ]))
+                    ])
+                )
+            )
+        ]
+
+        elements += [
+            DateConvertDecls.encodeDecl(),
+            DateConvertDecls.decodeDecl(),
+        ]
+
+        return TSSourceFile(elements)
+    }
+}
+
+fileprivate enum DateConvertDecls {
+    static func decodeDecl() -> TSFunctionDecl {
+        TSFunctionDecl(
+            modifiers: [.export],
+            name: "Date_decode",
+            params: [ .init(name: "unixMilli", type: TSIdentType("number"))],
+            body: TSBlockStmt([
+                TSReturnStmt(TSNewExpr(callee: TSIdentType("Date"), args: [TSIdentExpr("unixMilli")]))
+            ])
+        )
+    }
+
+    static func encodeDecl() -> TSFunctionDecl {
+        TSFunctionDecl(
+            modifiers: [.export],
+            name: "Date_encode",
+            params: [.init(name: "d", type: TSIdentType("Date"))],
+            body: TSBlockStmt([
+                TSReturnStmt(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("d"), name: "getTime"), args: []))
+            ])
+        )
+    }
+}

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -165,16 +165,8 @@ struct GenerateTSClient {
                     let orgStype = stype
                     var stype = stype
                     var updated = false
-//                    if stype.asStruct != nil {
-//                        print("checking.. '\(stype)' (\(type(of: stype)))")
-//                    }
-//                    if stype.asStruct?.decl.inheritedTypeReprs.isEmpty == false {
-//                        print(stype.asStruct!.decl.inheritedTypeReprs)
-//                        print(stype.asStruct!.decl.inheritedTypeReprs.map({ type(of: $0) }))
-//                    }
                     while let `struct` = stype.asStruct,
                           `struct`.nominalTypeDecl.inheritedTypes.contains(where: { (t) in t.description == "RawRepresentable" }) == true {
-//                        print("RawRepresentable struct '\(stype)' found!")
                         if let rawValueDecl = `struct`.decl.properties.first(where: { $0.name == "rawValue" }) {
                             stype = rawValueDecl.typeRepr.resolve(from: rawValueDecl.context)
                             updated = true
@@ -184,9 +176,12 @@ struct GenerateTSClient {
                         }
                     }
                     if updated,
-                       let name = stype.toTypeRepr(containsModule: false).asIdent?.elements.last?.name,
-                       let entry = typeMap.table[name] {
-                        return RawRepresentableConverter(generator: generator, swiftType: orgStype, lastEntry: entry)
+                       let name = stype.toTypeRepr(containsModule: false).asIdent?.elements.last?.name {
+                        if let entry = typeMap.table[name] {
+                            return RawRepresentableConverter(generator: generator, swiftType: orgStype, lastEntry: entry)
+                        } else {
+                            return RawRepresentableConverter(generator: generator, swiftType: orgStype, lastEntry: .identity(name: name))
+                        }
                     }
                     return nil
                 }),

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -24,104 +24,6 @@ struct GenerateTSClient {
         return TypeMap(table: typeMapTable)
     }()
 
-    private func generateCommon() -> TSSourceFile {
-        let string = TSIdentType.string
-        var elements: [any ASTNode] = [
-            TSInterfaceDecl(modifiers: [.export], name: "IStubClient", body: TSBlockStmt([
-                TSMethodDecl(
-                    name: "send", params: [
-                        .init(name: "request", type: TSIdentType.unknown),
-                        .init(name: "servicePath", type: TSIdentType.string)
-                    ],
-                    result: TSIdentType.promise(TSIdentType.unknown)
-                )
-            ])),
-            TSTypeDecl(modifiers: [.export], name: "Headers", type: TSIdentType("Record", genericArgs: [string, string])),
-            TSTypeDecl(modifiers: [.export], name: "StubClientOptions", type: TSObjectType([
-                .field(TSFieldDecl(name: "headers", isOptional: true, type: TSFunctionType(params: [], result: TSUnionType([
-                    TSIdentType("Headers"),
-                    TSIdentType("Promise", genericArgs: [TSIdentType("Headers")]),
-                ])))),
-                .field(TSFieldDecl(name: "mapResponseError", isOptional: true, type: TSFunctionType(params: [.init(name: "e", type: TSIdentType("FetchHTTPStubResponseError"))], result: TSIdentType.error))),
-            ])),
-            TSClassDecl(modifiers: [.export], name: "FetchHTTPStubResponseError", extends: TSIdentType("Error"), body: TSBlockStmt([
-                TSFieldDecl(modifiers: [.readonly], name: "path", type: string),
-                TSFieldDecl(modifiers: [.readonly], name: "response", type: TSIdentType("Response")),
-                TSMethodDecl(name: "constructor", params: [.init(name: "path", type: string), .init(name: "response", type: TSIdentType("Response"))], body: TSBlockStmt([
-                    TSCallExpr(callee: TSIdentExpr("super"), args: [TSTemplateLiteralExpr("ResponseError. path=\(ident: "path"), status=\(TSMemberExpr(base: TSIdentExpr("response"), name: "status"))")]),
-                    TSAssignExpr(TSMemberExpr(base: TSIdentExpr.this, name: "path"), TSIdentExpr("path")),
-                    TSAssignExpr(TSMemberExpr(base: TSIdentExpr.this, name: "response"), TSIdentExpr("response")),
-                ])),
-            ])),
-            TSVarDecl(
-                modifiers: [.export],
-                kind: .const,
-                name: "createStubClient",
-                initializer: TSClosureExpr(
-                    params: [
-                        .init(name: "baseURL", type: string),
-                        .init(name: "options", isOptional: true, type: TSIdentType("StubClientOptions")),
-                    ],
-                    result: TSIdentType("IStubClient"),
-                    body: TSBlockStmt([
-                        TSReturnStmt(TSObjectExpr([
-                            .method(TSMethodDecl(modifiers: [.async], name: "send", params: [.init(name: "request"), .init(name: "servicePath")], body: TSBlockStmt([
-                                TSVarDecl(kind: .let, name: "optionHeaders", type: TSIdentType("Headers"), initializer: TSObjectExpr([])),
-                                TSIfStmt(condition: TSMemberExpr(base: TSIdentExpr("options"), isOptional: true, name: "headers"), then: TSBlockStmt([
-                                    TSAssignExpr(
-                                        TSIdentExpr("optionHeaders"),
-                                        TSAwaitExpr(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("options"), name: "headers"), args: []))
-                                    ),
-                                ])),
-
-                                TSVarDecl(kind: .const, name: "res", initializer: TSAwaitExpr(TSCallExpr(callee: TSIdentExpr("fetch"), args: [
-                                    TSCallExpr(callee: TSMemberExpr(
-                                        base: TSNewExpr(callee: TSIdentType("URL"), args: [
-                                            TSIdentExpr("servicePath"),
-                                            TSIdentExpr("baseURL"),
-                                        ]),
-                                        name: "toString"
-                                    ), args: []),
-                                    TSObjectExpr([
-                                        .named(name: "method", value: TSStringLiteralExpr("POST")),
-                                        .named(name: "headers", value: TSObjectExpr([
-                                            .named(name: "Content-Type", value: TSStringLiteralExpr("application/json")),
-                                            .destructuring(value: TSIdentExpr("optionHeaders")),
-                                        ])),
-                                        .named(name: "body", value: TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("JSON"), name: "stringify"), args: [TSIdentExpr("request")])),
-                                    ]),
-                                ]))),
-                                TSIfStmt(condition: TSPrefixOperatorExpr("!", TSMemberExpr(base: TSIdentExpr("res"), name: "ok")), then: TSBlockStmt([
-                                    TSVarDecl(kind: .const, name: "e", initializer: TSNewExpr(callee: TSIdentType("FetchHTTPStubResponseError"), args: [
-                                        TSIdentExpr("servicePath"),
-                                        TSIdentExpr("res"),
-                                    ])),
-                                    TSIfStmt(
-                                        condition: TSMemberExpr(base: TSIdentExpr("options"), isOptional: true, name: "mapResponseError"),
-                                        then: TSBlockStmt([
-                                            TSThrowStmt(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("options"), name: "mapResponseError"), args: [TSIdentExpr("e")])),
-                                        ]),
-                                        else: TSBlockStmt([
-                                            TSThrowStmt(TSIdentExpr("e")),
-                                        ])
-                                    ),
-                                ])),
-                                TSReturnStmt(TSAwaitExpr(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("res"), name: "json"), args: []))),
-                            ])))
-                        ]))
-                    ])
-                )
-            )
-        ]
-
-        elements += [
-            DateConvertDecls.encodeDecl(),
-            DateConvertDecls.decodeDecl(),
-        ]
-
-        return TSSourceFile(elements)
-    }
-
     private func processFile(
         generator: CodeGenerator,
         swift: SourceFile,
@@ -289,30 +191,6 @@ struct GenerateTSClient {
         return Generator.OutputFile(
             name: URLs.relativePath(to: entry.file, from: dstDirectory).relativePath,
             content: entry.print()
-        )
-    }
-}
-
-fileprivate enum DateConvertDecls {
-    static func decodeDecl() -> TSFunctionDecl {
-        TSFunctionDecl(
-            modifiers: [.export],
-            name: "Date_decode",
-            params: [ .init(name: "unixMilli", type: TSIdentType("number"))],
-            body: TSBlockStmt([
-                TSReturnStmt(TSNewExpr(callee: TSIdentType("Date"), args: [TSIdentExpr("unixMilli")]))
-            ])
-        )
-    }
-
-    static func encodeDecl() -> TSFunctionDecl {
-        TSFunctionDecl(
-            modifiers: [.export],
-            name: "Date_encode",
-            params: [.init(name: "d", type: TSIdentType("Date"))],
-            body: TSBlockStmt([
-                TSReturnStmt(TSCallExpr(callee: TSMemberExpr(base: TSIdentExpr("d"), name: "getTime"), args: []))
-            ])
         )
     }
 }

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -240,18 +240,6 @@ struct FlatRawRepresentableConverter: TypeConverter {
     var doesRawRepresentableCoding: Bool
     var needsSpecialize: Bool
 
-//    func type(for target: GenerationTarget) throws -> any TSType {
-//        if case .json = target, needsSpecialize {
-//            return TSUnionType([
-////                try generator.converter(for: rawValueType.swiftType).type(for: target),
-//                try `default`.type(for: target),
-////                TSCustomType(text: "never /*  */"),
-//            ])
-//        }
-//
-//        return try `default`.type(for: target)
-//    }
-
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
         let name = try self.name(for: target)
         let genericParams: [TSTypeParameterNode] = try self.genericParams().map {

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -276,6 +276,7 @@ struct GenerateTSClient {
             var modules = input.context.modules
             modules.removeAll { $0 === input.context.swiftModule }
             var entries = try package.generate(modules: modules).entries
+            entries.removeAll(where: { $0.source.elements.isEmpty })
             entries.append(commonLib)
 
             for entry in entries {

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -307,14 +307,10 @@ struct FlatRawRepresentableConverter: TypeConverter {
 
     func callDecode(json: any TSExpr) throws -> any TSExpr {
         if needsSpecialize {
-            let value: any TSExpr
-            if doesRawRepresentableCoding {
-                value = try rawValueType.callDecodeField(json: json)
-            } else {
-                value = try rawValueType.callDecodeField(json: TSMemberExpr(base: TSIdentExpr("json"), name: "rawValue"))
-            }
+            let rawValue = doesRawRepresentableCoding ? json : TSMemberExpr(base: json, name: "rawValue")
+            let value = try rawValueType.callDecodeField(json: rawValue)
             let field = try rawValueType.valueToField(value: value, for: .entity)
-            return field
+            return TSAsExpr(field, try type(for: .entity))
         }
         return try `default`.callDecode(json: json)
     }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "branch" : "rawrepresentable",
-        "revision" : "1bb7474e3a3b0a5aa119cc0c8c6c5abc216f3d85"
+        "revision" : "d0163e47c80bbab53dbbebf1d750166c430401c5",
+        "version" : "2.9.0"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "composition_type",
-        "revision" : "21565f88e5c528c06eccd96ea677f09e200e6034"
+        "revision" : "18ee757dbb9aac67fdbb71545e8c246f4248cbb0",
+        "version" : "2.6.2"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "8c6c49a70eb3492e11393c16103156a0b9f66e09",
-        "version" : "2.6.0"
+        "branch" : "composition_type",
+        "revision" : "21565f88e5c528c06eccd96ea677f09e200e6034"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "5015235b2cd2143a4cec22fb5d79cfbd8a5c58a5",
-        "version" : "2.8.2"
+        "branch" : "rawrepresentable",
+        "revision" : "1bb7474e3a3b0a5aa119cc0c8c6c5abc216f3d85"
       }
     },
     {

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -12,6 +12,9 @@ public protocol EchoServiceProtocol {
     func emptyRequestAndResponse() async throws
 
     func testTypeAliasToRawRepr(request: Student) async throws -> Student
+    func testRawRepr(request: Student2) async throws -> Student2
+    func testRawRepr2(request: Student3) async throws -> Student3
+    func testRawRepr3(request: Student4) async throws -> Student4
 }
 
 public struct EchoHelloRequest: Codable, Sendable {

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -1,4 +1,4 @@
-public struct GenericIDz<T>: Codable & RawRepresentable & Sendable {
+public struct GenericID<T>: Codable & RawRepresentable & Sendable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -5,3 +5,11 @@ public struct GenericID<T>: Codable & RawRepresentable & Sendable {
 
     public var rawValue: String
 }
+
+public struct GenericID2<_IDSpecifier, RawValue: Sendable & Hashable & Codable>: RawRepresentable, Sendable, Hashable, Codable {
+    public var rawValue: RawValue { id }
+
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+}

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -6,10 +6,23 @@ public struct GenericID<T>: Codable & RawRepresentable & Sendable {
     public var rawValue: String
 }
 
-public struct GenericID2<_IDSpecifier, RawValue: Sendable & Hashable & Codable>: RawRepresentable, Sendable, Hashable, Codable {
-    public var rawValue: RawValue { id }
-
+public struct GenericID2<_IDSpecifier, RawValue: Sendable & Codable>: RawRepresentable, Sendable, Codable {
     public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
+
+    public var rawValue: RawValue
+}
+
+public enum MyValue: Codable, Sendable {
+    case id(String)
+    case none
+}
+
+public struct GenericID3<T>: Codable & RawRepresentable & Sendable {
+    public init(rawValue: MyValue) {
+        self.rawValue = rawValue
+    }
+
+    public var rawValue: MyValue
 }

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -20,9 +20,9 @@ public enum MyValue: Codable, Sendable {
 }
 
 public struct GenericID3<T>: Codable & RawRepresentable & Sendable {
-    public init(rawValue: MyValue) {
+    public init(rawValue: RawValue) {
         self.rawValue = rawValue
     }
-
-    public var rawValue: MyValue
+    public typealias RawValue = MyValue
+    public var rawValue: RawValue
 }

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -1,14 +1,14 @@
 public struct Student: Codable, Sendable {
-    public typealias IDz = GenericIDz<Student>
+    public typealias ID = GenericID<Student>
 
     public init(
-        id: IDz,
+        id: ID,
         name: String
     ) {
         self.id = id
         self.name = name
     }
 
-    public var id: IDz
+    public var id: ID
     public var name: String
 }

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -1,15 +1,43 @@
 public struct Student: Codable, Sendable {
     public typealias ID = GenericID<Student>
-    public typealias ID2 = GenericID2<Student, Int>
 
-    public init(
-        id: ID,
-        name: String
-    ) {
+    public init(id: ID, name: String) {
         self.id = id
         self.name = name
     }
+    public var id: ID
+    public var name: String
+}
 
+public struct Student2: Codable, Sendable {
+    public typealias ID = GenericID2<Student2, GenericID<Student2>>
+
+    public init(id: ID, name: String) {
+        self.id = id
+        self.name = name
+    }
+    public var id: ID
+    public var name: String
+}
+
+public struct Student3: Codable, Sendable {
+    public typealias ID = GenericID3<Student3>
+
+    public init(id: ID, name: String) {
+        self.id = id
+        self.name = name
+    }
+    public var id: ID
+    public var name: String
+}
+
+public struct Student4: Codable, Sendable {
+    public typealias ID = GenericID2<Student4, GenericID2<Student4, MyValue>>
+
+    public init(id: ID, name: String) {
+        self.id = id
+        self.name = name
+    }
     public var id: ID
     public var name: String
 }

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -10,7 +10,7 @@ public struct Student: Codable, Sendable {
 }
 
 public struct Student2: Codable, Sendable {
-    public typealias ID = GenericID2<Student2, GenericID<Student2>>
+    public typealias ID = GenericID2<Student2, String>
 
     public init(id: ID, name: String) {
         self.id = id

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -1,5 +1,6 @@
 public struct Student: Codable, Sendable {
     public typealias ID = GenericID<Student>
+    public typealias ID2 = GenericID2<Student, Int>
 
     public init(
         id: ID,

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -25,6 +25,15 @@ public struct EchoServiceStub<C: StubClientProtocol>: EchoServiceProtocol, Senda
     public func testTypeAliasToRawRepr(request: Student) async throws -> Student {
         return try await client.send(path: "Echo/testTypeAliasToRawRepr", request: request)
     }
+    public func testRawRepr(request: Student2) async throws -> Student2 {
+        return try await client.send(path: "Echo/testRawRepr", request: request)
+    }
+    public func testRawRepr2(request: Student3) async throws -> Student3 {
+        return try await client.send(path: "Echo/testRawRepr2", request: request)
+    }
+    public func testRawRepr3(request: Student4) async throws -> Student4 {
+        return try await client.send(path: "Echo/testRawRepr3", request: request)
+    }
 }
 
 extension StubClientProtocol {

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -59,6 +59,33 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
         }
 
         do {
+            let student: Student2 = .init(
+                id: Student2.ID(rawValue: .init(rawValue: "0002")),
+                name: "taro"
+            )
+            let res = try await client.echo.testRawRepr(request: student)
+            dump(res)
+        }
+
+        do {
+            let student: Student3 = .init(
+                id: Student3.ID(rawValue: .id("0003")),
+                name: "taro"
+            )
+            let res = try await client.echo.testRawRepr2(request: student)
+            dump(res)
+        }
+
+        do {
+            let student: Student4 = .init(
+                id: Student4.ID(rawValue: .init(rawValue: .id("0004"))),
+                name: "taro"
+            )
+            let res = try await client.echo.testRawRepr3(request: student)
+            dump(res)
+        }
+
+        do {
             let res = try await client.account.signin(request: .init(
                 email: "example@example.com",
                 password: "password"

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -51,7 +51,7 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
 
         do {
             let student: Student = .init(
-                id: Student.IDz(rawValue: "0001"),
+                id: Student.ID(rawValue: "0001"),
                 name: "taro"
             )
             let res = try await client.echo.testTypeAliasToRawRepr(request: student)

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -60,7 +60,7 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
 
         do {
             let student: Student2 = .init(
-                id: Student2.ID(rawValue: .init(rawValue: "0002")),
+                id: Student2.ID(rawValue: "0002"),
                 name: "taro"
             )
             let res = try await client.echo.testRawRepr(request: student)

--- a/example/Sources/Server/Gen/Echo.gen.swift
+++ b/example/Sources/Server/Gen/Echo.gen.swift
@@ -17,6 +17,9 @@ struct EchoServiceProvider<Bridge: VaporToServiceBridgeProtocol, Service: EchoSe
             group.post("testComplexType", use: bridge.makeHandler(serviceBuilder, { $0.testComplexType }))
             group.post("emptyRequestAndResponse", use: bridge.makeHandler(serviceBuilder, { $0.emptyRequestAndResponse }))
             group.post("testTypeAliasToRawRepr", use: bridge.makeHandler(serviceBuilder, { $0.testTypeAliasToRawRepr }))
+            group.post("testRawRepr", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr }))
+            group.post("testRawRepr2", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr2 }))
+            group.post("testRawRepr3", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr3 }))
         }
     }
 }

--- a/example/Sources/Server/main.swift
+++ b/example/Sources/Server/main.swift
@@ -5,8 +5,10 @@ let app = Application()
 defer { app.shutdown() }
 
 app.logger.logLevel = .error
+let logger = app.logger
 
 let myErrorMiddleware = ErrorMiddleware { _, error in
+    logger.error("\(error)")
     struct ErrorFrame: Encodable {
         var errorMessage: String
     }

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -30,4 +30,16 @@ struct EchoService: EchoServiceProtocol {
     func testTypeAliasToRawRepr(request: Student) async throws -> Student {
         return request
     }
+
+    func testRawRepr(request: Student2) async throws -> Student2 {
+        return request
+    }
+
+    func testRawRepr2(request: Student3) async throws -> Student3 {
+        return request
+    }
+
+    func testRawRepr3(request: Student4) async throws -> Student4 {
+        return request
+    }
 }

--- a/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
@@ -9,12 +9,17 @@ import {
 import {
     Student,
     Student2,
+    Student2_JSON,
+    Student2_decode,
+    Student2_encode,
     Student3,
     Student3_JSON,
     Student3_decode,
+    Student3_encode,
     Student4,
     Student4_JSON,
-    Student4_decode
+    Student4_decode,
+    Student4_encode
 } from "./Entity/Student.gen.js";
 import { User } from "./Entity/User.gen.js";
 
@@ -53,14 +58,15 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
             return await stub.send(request, "Echo/testTypeAliasToRawRepr") as Student;
         },
         async testRawRepr(request: Student2): Promise<Student2> {
-            return await stub.send(request, "Echo/testRawRepr") as Student2;
+            const json = await stub.send(Student2_encode(request), "Echo/testRawRepr") as Student2_JSON;
+            return Student2_decode(json);
         },
         async testRawRepr2(request: Student3): Promise<Student3> {
-            const json = await stub.send(request, "Echo/testRawRepr2") as Student3_JSON;
+            const json = await stub.send(Student3_encode(request), "Echo/testRawRepr2") as Student3_JSON;
             return Student3_decode(json);
         },
         async testRawRepr3(request: Student4): Promise<Student4> {
-            const json = await stub.send(request, "Echo/testRawRepr3") as Student4_JSON;
+            const json = await stub.send(Student4_encode(request), "Echo/testRawRepr3") as Student4_JSON;
             return Student4_decode(json);
         }
     };

--- a/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
@@ -6,18 +6,8 @@ import {
     TagRecord,
     identity
 } from "../common.gen.js";
-import {
-    Student,
-    Student_JSON,
-    Student_decode,
-    Student_encode
-} from "./Entity/Student.gen.js";
-import {
-    User,
-    User_JSON,
-    User_decode,
-    User_encode
-} from "./Entity/User.gen.js";
+import { Student } from "./Entity/Student.gen.js";
+import { User } from "./Entity/User.gen.js";
 
 export interface IEchoClient {
     hello(request: EchoHelloRequest): Promise<EchoHelloResponse>;
@@ -38,8 +28,7 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
             return Date_decode(json);
         },
         async testTypicalEntity(request: User): Promise<User> {
-            const json = await stub.send(User_encode(request), "Echo/testTypicalEntity") as User_JSON;
-            return User_decode(json);
+            return await stub.send(request, "Echo/testTypicalEntity") as User;
         },
         async testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response> {
             const json = await stub.send(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
@@ -49,8 +38,7 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
             return await stub.send({}, "Echo/emptyRequestAndResponse") as void;
         },
         async testTypeAliasToRawRepr(request: Student): Promise<Student> {
-            const json = await stub.send(Student_encode(request), "Echo/testTypeAliasToRawRepr") as Student_JSON;
-            return Student_decode(json);
+            return await stub.send(request, "Echo/testTypeAliasToRawRepr") as Student;
         }
     };
 };

--- a/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
@@ -6,7 +6,16 @@ import {
     TagRecord,
     identity
 } from "../common.gen.js";
-import { Student } from "./Entity/Student.gen.js";
+import {
+    Student,
+    Student2,
+    Student3,
+    Student3_JSON,
+    Student3_decode,
+    Student4,
+    Student4_JSON,
+    Student4_decode
+} from "./Entity/Student.gen.js";
 import { User } from "./Entity/User.gen.js";
 
 export interface IEchoClient {
@@ -16,6 +25,9 @@ export interface IEchoClient {
     testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response>;
     emptyRequestAndResponse(): Promise<void>;
     testTypeAliasToRawRepr(request: Student): Promise<Student>;
+    testRawRepr(request: Student2): Promise<Student2>;
+    testRawRepr2(request: Student3): Promise<Student3>;
+    testRawRepr3(request: Student4): Promise<Student4>;
 }
 
 export const bindEcho = (stub: IStubClient): IEchoClient => {
@@ -39,6 +51,17 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
         },
         async testTypeAliasToRawRepr(request: Student): Promise<Student> {
             return await stub.send(request, "Echo/testTypeAliasToRawRepr") as Student;
+        },
+        async testRawRepr(request: Student2): Promise<Student2> {
+            return await stub.send(request, "Echo/testRawRepr") as Student2;
+        },
+        async testRawRepr2(request: Student3): Promise<Student3> {
+            const json = await stub.send(request, "Echo/testRawRepr2") as Student3_JSON;
+            return Student3_decode(json);
+        },
+        async testRawRepr3(request: Student4): Promise<Student4> {
+            const json = await stub.send(request, "Echo/testRawRepr3") as Student4_JSON;
+            return Student4_decode(json);
         }
     };
 };

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -4,7 +4,9 @@ export type GenericID<T> = string & TagRecord<"GenericID", [T]>;
 
 export type GenericID2<_IDSpecifier, RawValue> = RawValue & TagRecord<"GenericID2", [_IDSpecifier, RawValue]>;
 
-export type GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> = RawValue_JSON;
+export type GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> = {
+    rawValue: RawValue_JSON;
+};
 
 export function GenericID2_decode<
     _IDSpecifier,
@@ -12,7 +14,7 @@ export function GenericID2_decode<
     RawValue,
     RawValue_JSON
 >(json: GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON>, _IDSpecifier_decode: (json: _IDSpecifier_JSON) => _IDSpecifier, RawValue_decode: (json: RawValue_JSON) => RawValue): GenericID2<_IDSpecifier, RawValue> {
-    return RawValue_decode(json) as GenericID2<_IDSpecifier, RawValue>;
+    return RawValue_decode(json.rawValue) as GenericID2<_IDSpecifier, RawValue>;
 }
 
 export function GenericID2_encode<
@@ -21,7 +23,9 @@ export function GenericID2_encode<
     RawValue,
     RawValue_JSON
 >(entity: GenericID2<_IDSpecifier, RawValue>, _IDSpecifier_encode: (entity: _IDSpecifier) => _IDSpecifier_JSON, RawValue_encode: (entity: RawValue) => RawValue_JSON): GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> {
-    return RawValue_encode(entity);
+    return {
+        rawValue: RawValue_encode(entity)
+    };
 }
 
 export type MyValue = ({
@@ -64,8 +68,24 @@ export function MyValue_decode(json: MyValue_JSON): MyValue {
 
 export type GenericID3<T> = MyValue & TagRecord<"GenericID3", [T]>;
 
-export type GenericID3_JSON<T_JSON> = MyValue_JSON;
+export type GenericID3_JSON<T_JSON> = {
+    rawValue: MyValue_JSON;
+};
 
 export function GenericID3_decode<T, T_JSON>(json: GenericID3_JSON<T_JSON>, T_decode: (json: T_JSON) => T): GenericID3<T> {
-    return MyValue_decode(json) as GenericID3<T>;
+    return MyValue_decode(json.rawValue) as GenericID3<T>;
+}
+
+export function GenericID3_encode<T, T_JSON>(entity: GenericID3<T>, T_encode: (entity: T) => T_JSON): GenericID3_JSON<T_JSON> {
+    return {
+        rawValue: entity as MyValue_JSON
+    };
+}
+
+export type GenericID3_RawValue = MyValue;
+
+export type GenericID3_RawValue_JSON = MyValue_JSON;
+
+export function GenericID3_RawValue_decode(json: GenericID3_RawValue_JSON): GenericID3_RawValue {
+    return MyValue_decode(json);
 }

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -1,17 +1,3 @@
 import { TagRecord } from "../../common.gen.js";
 
-export type GenericIDz<T> = {
-    rawValue: string;
-} & TagRecord<"GenericIDz", [T]>;
-
-export type GenericIDz_JSON<T_JSON> = string;
-
-export function GenericIDz_decode<T, T_JSON>(json: GenericIDz_JSON<T_JSON>, T_decode: (json: T_JSON) => T): GenericIDz<T> {
-    return {
-        rawValue: json
-    };
-}
-
-export function GenericIDz_encode<T, T_JSON>(entity: GenericIDz<T>, T_encode: (entity: T) => T_JSON): GenericIDz_JSON<T_JSON> {
-    return entity.rawValue;
-}
+export type GenericID<T> = string & TagRecord<"GenericID", [T]>;

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -1,3 +1,5 @@
 import { TagRecord } from "../../common.gen.js";
 
 export type GenericID<T> = string & TagRecord<"GenericID", [T]>;
+
+export type GenericID2<_IDSpecifier, RawValue> = RawValue & TagRecord<"GenericID2", [_IDSpecifier, RawValue]>;

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -3,3 +3,69 @@ import { TagRecord } from "../../common.gen.js";
 export type GenericID<T> = string & TagRecord<"GenericID", [T]>;
 
 export type GenericID2<_IDSpecifier, RawValue> = RawValue & TagRecord<"GenericID2", [_IDSpecifier, RawValue]>;
+
+export type GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> = RawValue_JSON;
+
+export function GenericID2_decode<
+    _IDSpecifier,
+    _IDSpecifier_JSON,
+    RawValue,
+    RawValue_JSON
+>(json: GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON>, _IDSpecifier_decode: (json: _IDSpecifier_JSON) => _IDSpecifier, RawValue_decode: (json: RawValue_JSON) => RawValue): GenericID2<_IDSpecifier, RawValue> {
+    return RawValue_decode(json) as GenericID2<_IDSpecifier, RawValue>;
+}
+
+export function GenericID2_encode<
+    _IDSpecifier,
+    _IDSpecifier_JSON,
+    RawValue,
+    RawValue_JSON
+>(entity: GenericID2<_IDSpecifier, RawValue>, _IDSpecifier_encode: (entity: _IDSpecifier) => _IDSpecifier_JSON, RawValue_encode: (entity: RawValue) => RawValue_JSON): GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> {
+    return RawValue_encode(entity);
+}
+
+export type MyValue = ({
+    kind: "id";
+    id: {
+        _0: string;
+    };
+} | {
+    kind: "none";
+    none: {};
+}) & TagRecord<"MyValue">;
+
+export type MyValue_JSON = {
+    id: {
+        _0: string;
+    };
+} | {
+    none: {};
+};
+
+export function MyValue_decode(json: MyValue_JSON): MyValue {
+    if ("id" in json) {
+        const j = json.id;
+        const _0 = j._0;
+        return {
+            kind: "id",
+            id: {
+                _0: _0
+            }
+        };
+    } else if ("none" in json) {
+        return {
+            kind: "none",
+            none: {}
+        };
+    } else {
+        throw new Error("unknown kind");
+    }
+}
+
+export type GenericID3<T> = MyValue & TagRecord<"GenericID3", [T]>;
+
+export type GenericID3_JSON<T_JSON> = MyValue_JSON;
+
+export function GenericID3_decode<T, T_JSON>(json: GenericID3_JSON<T_JSON>, T_decode: (json: T_JSON) => T): GenericID3<T> {
+    return MyValue_decode(json) as GenericID3<T>;
+}

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -3,10 +3,10 @@ import {
     GenericID,
     GenericID2,
     GenericID2_JSON,
-    GenericID2_decode,
     GenericID3,
     GenericID3_JSON,
     GenericID3_decode,
+    GenericID3_encode,
     MyValue,
     MyValue_JSON,
     MyValue_decode
@@ -24,7 +24,42 @@ export type Student2 = {
     name: string;
 } & TagRecord<"Student2">;
 
+export type Student2_JSON = {
+    id: Student2_ID_JSON;
+    name: string;
+};
+
+export function Student2_decode(json: Student2_JSON): Student2 {
+    const id = Student2_ID_decode(json.id);
+    const name = json.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
+export function Student2_encode(entity: Student2): Student2_JSON {
+    const id = Student2_ID_encode(entity.id);
+    const name = entity.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
 export type Student2_ID = GenericID2<Student2, GenericID<Student2>>;
+
+export type Student2_ID_JSON = GenericID2_JSON<Student2_JSON, GenericID<Student2_JSON>>;
+
+export function Student2_ID_decode(json: Student2_ID_JSON): Student2_ID {
+    return json.rawValue as GenericID<Student2>;
+}
+
+export function Student2_ID_encode(entity: Student2_ID): Student2_ID_JSON {
+    return {
+        rawValue: entity as GenericID<Student2_JSON>
+    };
+}
 
 export type Student3 = {
     id: Student3_ID;
@@ -45,12 +80,25 @@ export function Student3_decode(json: Student3_JSON): Student3 {
     };
 }
 
+export function Student3_encode(entity: Student3): Student3_JSON {
+    const id = Student3_ID_encode(entity.id);
+    const name = entity.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
 export type Student3_ID = GenericID3<Student3>;
 
 export type Student3_ID_JSON = GenericID3_JSON<Student3_JSON>;
 
 export function Student3_ID_decode(json: Student3_ID_JSON): Student3_ID {
     return GenericID3_decode<Student3, Student3_JSON>(json, Student3_decode);
+}
+
+export function Student3_ID_encode(entity: Student3_ID): Student3_ID_JSON {
+    return GenericID3_encode<Student3, Student3_JSON>(entity, Student3_encode);
 }
 
 export type Student4 = {
@@ -72,22 +120,27 @@ export function Student4_decode(json: Student4_JSON): Student4 {
     };
 }
 
+export function Student4_encode(entity: Student4): Student4_JSON {
+    const id = Student4_ID_encode(entity.id);
+    const name = entity.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
 export type Student4_ID = GenericID2<Student4, GenericID2<Student4, MyValue>>;
 
 export type Student4_ID_JSON = GenericID2_JSON<Student4_JSON, GenericID2_JSON<Student4_JSON, MyValue_JSON>>;
 
 export function Student4_ID_decode(json: Student4_ID_JSON): Student4_ID {
-    return GenericID2_decode<
-        Student4,
-        Student4_JSON,
-        GenericID2<Student4, MyValue>,
-        GenericID2_JSON<Student4_JSON, MyValue_JSON>
-    >(json, Student4_decode, (json: GenericID2_JSON<Student4_JSON, MyValue_JSON>): GenericID2<Student4, MyValue> => {
-        return GenericID2_decode<
-            Student4,
-            Student4_JSON,
-            MyValue,
-            MyValue_JSON
-        >(json, Student4_decode, MyValue_decode);
-    });
+    return MyValue_decode(json.rawValue);
+}
+
+export function Student4_ID_encode(entity: Student4_ID): Student4_ID_JSON {
+    return {
+        rawValue: {
+            rawValue: entity as MyValue_JSON
+        }
+    };
 }

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -1,8 +1,10 @@
-import { TagRecord } from "../../common.gen.js";
+import { TagRecord, identity } from "../../common.gen.js";
 import {
     GenericID,
     GenericID2,
     GenericID2_JSON,
+    GenericID2_decode,
+    GenericID2_encode,
     GenericID3,
     GenericID3_JSON,
     GenericID3_decode,
@@ -47,18 +49,26 @@ export function Student2_encode(entity: Student2): Student2_JSON {
     };
 }
 
-export type Student2_ID = GenericID2<Student2, GenericID<Student2>>;
+export type Student2_ID = GenericID2<Student2, string>;
 
-export type Student2_ID_JSON = GenericID2_JSON<Student2_JSON, GenericID<Student2_JSON>>;
+export type Student2_ID_JSON = GenericID2_JSON<Student2_JSON, string>;
 
 export function Student2_ID_decode(json: Student2_ID_JSON): Student2_ID {
-    return json.rawValue as GenericID<Student2> as GenericID2<Student2, GenericID<Student2>>;
+    return GenericID2_decode<
+        Student2,
+        Student2_JSON,
+        string,
+        string
+    >(json, Student2_decode, identity);
 }
 
 export function Student2_ID_encode(entity: Student2_ID): Student2_ID_JSON {
-    return {
-        rawValue: entity as GenericID<Student2_JSON>
-    };
+    return GenericID2_encode<
+        Student2,
+        Student2_JSON,
+        string,
+        string
+    >(entity, Student2_encode, identity);
 }
 
 export type Student3 = {
@@ -134,13 +144,33 @@ export type Student4_ID = GenericID2<Student4, GenericID2<Student4, MyValue>>;
 export type Student4_ID_JSON = GenericID2_JSON<Student4_JSON, GenericID2_JSON<Student4_JSON, MyValue_JSON>>;
 
 export function Student4_ID_decode(json: Student4_ID_JSON): Student4_ID {
-    return MyValue_decode(json.rawValue.rawValue) as GenericID2<Student4, MyValue> as GenericID2<Student4, GenericID2<Student4, MyValue>>;
+    return GenericID2_decode<
+        Student4,
+        Student4_JSON,
+        GenericID2<Student4, MyValue>,
+        GenericID2_JSON<Student4_JSON, MyValue_JSON>
+    >(json, Student4_decode, (json: GenericID2_JSON<Student4_JSON, MyValue_JSON>): GenericID2<Student4, MyValue> => {
+        return GenericID2_decode<
+            Student4,
+            Student4_JSON,
+            MyValue,
+            MyValue_JSON
+        >(json, Student4_decode, MyValue_decode);
+    });
 }
 
 export function Student4_ID_encode(entity: Student4_ID): Student4_ID_JSON {
-    return {
-        rawValue: {
-            rawValue: entity as MyValue_JSON
-        }
-    };
+    return GenericID2_encode<
+        Student4,
+        Student4_JSON,
+        GenericID2<Student4, MyValue>,
+        GenericID2_JSON<Student4_JSON, MyValue_JSON>
+    >(entity, Student4_encode, (entity: GenericID2<Student4, MyValue>): GenericID2_JSON<Student4_JSON, MyValue_JSON> => {
+        return GenericID2_encode<
+            Student4,
+            Student4_JSON,
+            MyValue,
+            MyValue_JSON
+        >(entity, Student4_encode, identity);
+    });
 }

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -52,7 +52,7 @@ export type Student2_ID = GenericID2<Student2, GenericID<Student2>>;
 export type Student2_ID_JSON = GenericID2_JSON<Student2_JSON, GenericID<Student2_JSON>>;
 
 export function Student2_ID_decode(json: Student2_ID_JSON): Student2_ID {
-    return json.rawValue as GenericID<Student2>;
+    return json.rawValue as GenericID<Student2> as GenericID2<Student2, GenericID<Student2>>;
 }
 
 export function Student2_ID_encode(entity: Student2_ID): Student2_ID_JSON {
@@ -134,7 +134,7 @@ export type Student4_ID = GenericID2<Student4, GenericID2<Student4, MyValue>>;
 export type Student4_ID_JSON = GenericID2_JSON<Student4_JSON, GenericID2_JSON<Student4_JSON, MyValue_JSON>>;
 
 export function Student4_ID_decode(json: Student4_ID_JSON): Student4_ID {
-    return MyValue_decode(json.rawValue);
+    return MyValue_decode(json.rawValue.rawValue) as GenericID2<Student4, MyValue> as GenericID2<Student4, GenericID2<Student4, MyValue>>;
 }
 
 export function Student4_ID_encode(entity: Student4_ID): Student4_ID_JSON {

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -1,5 +1,5 @@
 import { TagRecord } from "../../common.gen.js";
-import { GenericID } from "./GenericID.gen.js";
+import { GenericID, GenericID2 } from "./GenericID.gen.js";
 
 export type Student = {
     id: Student_ID;
@@ -7,3 +7,5 @@ export type Student = {
 } & TagRecord<"Student">;
 
 export type Student_ID = GenericID<Student>;
+
+export type Student_ID2 = GenericID2<Student, number>;

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -1,47 +1,9 @@
 import { TagRecord } from "../../common.gen.js";
-import {
-    GenericIDz,
-    GenericIDz_JSON,
-    GenericIDz_decode,
-    GenericIDz_encode
-} from "./GenericID.gen.js";
+import { GenericID } from "./GenericID.gen.js";
 
 export type Student = {
-    id: Student_IDz;
+    id: Student_ID;
     name: string;
 } & TagRecord<"Student">;
 
-export type Student_JSON = {
-    id: Student_IDz_JSON;
-    name: string;
-};
-
-export function Student_decode(json: Student_JSON): Student {
-    const id = Student_IDz_decode(json.id);
-    const name = json.name;
-    return {
-        id: id,
-        name: name
-    };
-}
-
-export function Student_encode(entity: Student): Student_JSON {
-    const id = Student_IDz_encode(entity.id);
-    const name = entity.name;
-    return {
-        id: id,
-        name: name
-    };
-}
-
-export type Student_IDz = GenericIDz<Student>;
-
-export type Student_IDz_JSON = GenericIDz_JSON<Student_JSON>;
-
-export function Student_IDz_decode(json: Student_IDz_JSON): Student_IDz {
-    return GenericIDz_decode<Student, Student_JSON>(json, Student_decode);
-}
-
-export function Student_IDz_encode(entity: Student_IDz): Student_IDz_JSON {
-    return GenericIDz_encode<Student, Student_JSON>(entity, Student_encode);
-}
+export type Student_ID = GenericID<Student>;

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -1,5 +1,16 @@
 import { TagRecord } from "../../common.gen.js";
-import { GenericID, GenericID2 } from "./GenericID.gen.js";
+import {
+    GenericID,
+    GenericID2,
+    GenericID2_JSON,
+    GenericID2_decode,
+    GenericID3,
+    GenericID3_JSON,
+    GenericID3_decode,
+    MyValue,
+    MyValue_JSON,
+    MyValue_decode
+} from "./GenericID.gen.js";
 
 export type Student = {
     id: Student_ID;
@@ -8,4 +19,75 @@ export type Student = {
 
 export type Student_ID = GenericID<Student>;
 
-export type Student_ID2 = GenericID2<Student, number>;
+export type Student2 = {
+    id: Student2_ID;
+    name: string;
+} & TagRecord<"Student2">;
+
+export type Student2_ID = GenericID2<Student2, GenericID<Student2>>;
+
+export type Student3 = {
+    id: Student3_ID;
+    name: string;
+} & TagRecord<"Student3">;
+
+export type Student3_JSON = {
+    id: Student3_ID_JSON;
+    name: string;
+};
+
+export function Student3_decode(json: Student3_JSON): Student3 {
+    const id = Student3_ID_decode(json.id);
+    const name = json.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
+export type Student3_ID = GenericID3<Student3>;
+
+export type Student3_ID_JSON = GenericID3_JSON<Student3_JSON>;
+
+export function Student3_ID_decode(json: Student3_ID_JSON): Student3_ID {
+    return GenericID3_decode<Student3, Student3_JSON>(json, Student3_decode);
+}
+
+export type Student4 = {
+    id: Student4_ID;
+    name: string;
+} & TagRecord<"Student4">;
+
+export type Student4_JSON = {
+    id: Student4_ID_JSON;
+    name: string;
+};
+
+export function Student4_decode(json: Student4_JSON): Student4 {
+    const id = Student4_ID_decode(json.id);
+    const name = json.name;
+    return {
+        id: id,
+        name: name
+    };
+}
+
+export type Student4_ID = GenericID2<Student4, GenericID2<Student4, MyValue>>;
+
+export type Student4_ID_JSON = GenericID2_JSON<Student4_JSON, GenericID2_JSON<Student4_JSON, MyValue_JSON>>;
+
+export function Student4_ID_decode(json: Student4_ID_JSON): Student4_ID {
+    return GenericID2_decode<
+        Student4,
+        Student4_JSON,
+        GenericID2<Student4, MyValue>,
+        GenericID2_JSON<Student4_JSON, MyValue_JSON>
+    >(json, Student4_decode, (json: GenericID2_JSON<Student4_JSON, MyValue_JSON>): GenericID2<Student4, MyValue> => {
+        return GenericID2_decode<
+            Student4,
+            Student4_JSON,
+            MyValue,
+            MyValue_JSON
+        >(json, Student4_decode, MyValue_decode);
+    });
+}

--- a/example/TSClient/src/Gen/APIDefinition/Entity/User.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/User.gen.ts
@@ -5,41 +5,4 @@ export type User = {
     name: string;
 } & TagRecord<"User">;
 
-export type User_JSON = {
-    id: User_ID_JSON;
-    name: string;
-};
-
-export function User_decode(json: User_JSON): User {
-    const id = User_ID_decode(json.id);
-    const name = json.name;
-    return {
-        id: id,
-        name: name
-    };
-}
-
-export function User_encode(entity: User): User_JSON {
-    const id = User_ID_encode(entity.id);
-    const name = entity.name;
-    return {
-        id: id,
-        name: name
-    };
-}
-
-export type User_ID = {
-    rawValue: string;
-} & TagRecord<"User_ID">;
-
-export type User_ID_JSON = string;
-
-export function User_ID_decode(json: User_ID_JSON): User_ID {
-    return {
-        rawValue: json
-    };
-}
-
-export function User_ID_encode(entity: User_ID): User_ID_JSON {
-    return entity.rawValue;
-}
+export type User_ID = string & TagRecord<"User_ID">;

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,6 +1,6 @@
 import { bindAccount } from "./Gen/APIDefinition/Account.gen.js";
 import { bindEcho } from "./Gen/APIDefinition/Echo.gen.js";
-import { Student, Student_IDz } from "./Gen/APIDefinition/Entity/Student.gen.js";
+import { Student } from "./Gen/APIDefinition/Entity/Student.gen.js";
 import { User_ID } from "./Gen/APIDefinition/Entity/User.gen.js";
 import { createStubClient } from "./Gen/CallableKit.gen.js";
 
@@ -20,7 +20,7 @@ async function main() {
   }
 
   {
-    const id = { rawValue: "id" } as User_ID;
+    const id = "id" as User_ID;
     const res = await echoClient.testTypicalEntity({ id, name: "name" });
     console.log(JSON.stringify(res));
   }
@@ -45,7 +45,7 @@ async function main() {
 
   {
     const student: Student = {
-      id: { rawValue: "0001" } as Student_IDz,
+      id: "0001",
       name: "taro"
     }
     const res = await echoClient.testTypeAliasToRawRepr(student);

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,6 +1,6 @@
 import { bindAccount } from "./Gen/APIDefinition/Account.gen.js";
 import { bindEcho } from "./Gen/APIDefinition/Echo.gen.js";
-import { Student } from "./Gen/APIDefinition/Entity/Student.gen.js";
+import { Student, Student2, Student3, Student4 } from "./Gen/APIDefinition/Entity/Student.gen.js";
 import { User_ID } from "./Gen/APIDefinition/Entity/User.gen.js";
 import { createStubClient } from "./Gen/CallableKit.gen.js";
 
@@ -49,6 +49,33 @@ async function main() {
       name: "taro"
     }
     const res = await echoClient.testTypeAliasToRawRepr(student);
+    console.log(JSON.stringify(res));
+  }
+
+  {
+    const student: Student2 = {
+      id: "0002",
+      name: "taro"
+    }
+    const res = await echoClient.testRawRepr(student);
+    console.log(JSON.stringify(res));
+  }
+
+  {
+    const student: Student3 = {
+      id: { kind: "id", id: { _0: "0003" }},
+      name: "taro"
+    }
+    const res = await echoClient.testRawRepr2(student);
+    console.log(JSON.stringify(res));
+  }
+
+  {
+    const student: Student4 = {
+      id: { kind: "id", id: { _0: "0004" }},
+      name: "taro"
+    }
+    const res = await echoClient.testRawRepr3(student);
     console.log(JSON.stringify(res));
   }
 


### PR DESCRIPTION
`RawRepresentable`な型に関して、TS側では`rawValue`を展開した型をそのまま利用できるようにする。
これまで、
```ts
{
  rawValue: {
    rawValue: string
  }
}
```

のような型が登場していてTS側で扱いづらい形になっていた。
`RawRepresentable`のCodable表現は、プリミティブな型に対してはデフォルトで`rawValue`に譲渡する実装がSwift標準で提供されているため、それにならって最終的にプリミティブなRawValue型が得られた場合はその型をそのままTypeScript側で用いられるようにする。