### PR TITLE
Add missing support for argument outer name

### DIFF
--- a/Sources/CallableKit/GenerateSwiftClient.swift
+++ b/Sources/CallableKit/GenerateSwiftClient.swift
@@ -64,6 +64,7 @@ extension StubClientProtocol {
 
     private func generateFoundationHTTPStubClient() -> String {
 #"""
+#if !DISABLE_FOUNDATION_NETWORKING
 import Foundation
 #if canImport(FoundationNetworking)
 @preconcurrency import FoundationNetworking
@@ -188,6 +189,7 @@ extension URLSession {
         })
     }
 }
+#endif
 #endif
 
 """#

--- a/Sources/CallableKit/GenerateSwiftClient.swift
+++ b/Sources/CallableKit/GenerateSwiftClient.swift
@@ -207,7 +207,7 @@ public struct \(stubTypeName)<C: StubClientProtocol>: \(stype.name), Sendable {
 \(stype.functions.map { f in
     let retVal = f.response.map { " -> \($0.typeName)" } ?? ""
     return """
-    public func \(f.name)(\(f.request.map { "\($0.argName): \($0.typeName)" } ?? "")) async throws\(retVal) {
+    public func \(f.name)(\(f.request.map { "\($0.argOuterName.map({ "\($0) " }) ?? "")\($0.argName): \($0.typeName)" } ?? "")) async throws\(retVal) {
         return try await client.send(path: "\(stype.serviceName)/\(f.name)"\(f.request.map { ", request: \($0.argName)" } ??  ""))
     }
 """ }.joined(separator: "\n"))

--- a/Sources/CallableKit/ServiceProtocolScanner.swift
+++ b/Sources/CallableKit/ServiceProtocolScanner.swift
@@ -8,6 +8,7 @@ struct ServiceProtocolType {
     struct Function {
         var name: String
         struct Request {
+            var argOuterName: String?
             var argName: String
             var typeName: String
             var raw: any SType
@@ -52,7 +53,7 @@ enum ServiceProtocolScanner {
             return ServiceProtocolType.Function(
                 name: fdecl.name,
                 request: fdecl.parameters.first.map {
-                    .init(argName: $0.name!, typeName: $0.interfaceType.description, raw: $0.interfaceType)
+                    .init(argOuterName: $0.outerName, argName: $0.name!, typeName: $0.interfaceType.description, raw: $0.interfaceType)
                 },
                 response: fdecl.resultTypeRepr.map {
                     .init(

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol EchoServiceProtocol {
     func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse
 
-    func tommorow(now: Date) async throws -> Date
+    func tommorow(from now: Date) async throws -> Date
 
     func testTypicalEntity(request: User) async throws -> User
 

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -10,7 +10,7 @@ public struct EchoServiceStub<C: StubClientProtocol>: EchoServiceProtocol, Senda
     public func hello(request: EchoHelloRequest) async throws -> EchoHelloResponse {
         return try await client.send(path: "Echo/hello", request: request)
     }
-    public func tommorow(now: Date) async throws -> Date {
+    public func tommorow(from now: Date) async throws -> Date {
         return try await client.send(path: "Echo/tommorow", request: now)
     }
     public func testTypicalEntity(request: User) async throws -> User {

--- a/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
+++ b/example/Sources/Client/Gen/FoundationHTTPStubClient.gen.swift
@@ -1,3 +1,4 @@
+#if !DISABLE_FOUNDATION_NETWORKING
 import Foundation
 #if canImport(FoundationNetworking)
 @preconcurrency import FoundationNetworking
@@ -122,4 +123,5 @@ extension URLSession {
         })
     }
 }
+#endif
 #endif

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -26,7 +26,7 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
         }
 
         do {
-            let res = try await client.echo.tommorow(now: Date())
+            let res = try await client.echo.tommorow(from: Date())
             print(res)
         }
 

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -12,7 +12,7 @@ struct EchoService: EchoServiceProtocol {
         )
     }
 
-    func tommorow(now: Date) async throws -> Date {
+    func tommorow(from now: Date) async throws -> Date {
         now.addingTimeInterval(60 * 60 * 24 * 1)
     }
 


### PR DESCRIPTION
and add DISABLE_FOUNDATION_NETWORKING flag. To unlink `libcurl4-openssl-dev` on linux.