### PR TITLE
Add @CallableKit marker comment option

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "483ee3e0b4181e6472604d1f21e3bf905f892c61",
-        "version" : "2.10.0"
+        "revision" : "8654d6ff35c9823cff38a6f9dd2aa0e6aed2769b",
+        "version" : "2.11.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
-        "version" : "508.0.0"
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "18ee757dbb9aac67fdbb71545e8c246f4248cbb0",
-        "version" : "2.6.2"
+        "revision" : "12390490318962cad1b82a5d4ee57363ff2dbdcf",
+        "version" : "2.8.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -10,9 +10,9 @@ let package = Package(
         .library(name: "CallableKit", targets: ["CallableKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.10.0"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript", from: "2.11.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.8.0"),
     ],
     targets: [
         .executableTarget(
@@ -27,6 +27,9 @@ let package = Package(
             dependencies: [
                 "CodableToTypeScript",
                 "SwiftTypeReader"
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals"),
             ]
         )
     ]

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -227,7 +227,7 @@ struct FlatRawRepresentableConverter: TypeConverter {
         self.swiftType = swiftType
         self.rawValueType = try generator.converter(for: substituted)
         self.isTransferringRawValueType = swiftType.asStruct?.rawValueType(requiresTransferringRawValueType: true) != nil
-          || transferringRawValue
+        || transferringRawValue
     }
 
     var generator: CodeGenerator

--- a/Sources/CallableKit/GenerateTSClient.swift
+++ b/Sources/CallableKit/GenerateTSClient.swift
@@ -163,7 +163,21 @@ struct GenerateTSClient {
                 context: input.context,
                 typeConverterProvider: TypeConverterProvider(typeMap: typeMap, customProvider: { (generator, stype) in
                     if let rawValueType = stype.asStruct?.rawValueType(requiresTransferringRawValueType: false) {
-                        return try? FlatRawRepresentableConverter(generator: generator, swiftType: stype, rawValueType: rawValueType)
+                        var transferringRawValue = false
+                        if let comment = stype.asNominal?.nominalTypeDecl.comment,
+                           let match = comment.firstMatch(of: /@CallableKit\((.+?)\)/) {
+                            let options = extractOptions(match.output.1)
+                            if options["transferringRawValue"] == "true" {
+                                transferringRawValue = true
+                            }
+                        }
+
+                        return try? FlatRawRepresentableConverter(
+                            generator: generator,
+                            swiftType: stype,
+                            rawValueType: rawValueType,
+                            transferringRawValue: transferringRawValue
+                        )
                     }
 
                     return nil
@@ -201,16 +215,19 @@ struct GenerateTSClient {
     }
 }
 
+// TS側で.rawValueを経由せず直接RawValueで扱えるようにするコンバータ
 struct FlatRawRepresentableConverter: TypeConverter {
     init(
         generator: CodeGenerator,
         swiftType: any SType,
-        rawValueType substituted: any SType
+        rawValueType substituted: any SType,
+        transferringRawValue: Bool
     ) throws {
         self.generator = generator
         self.swiftType = swiftType
         self.rawValueType = try generator.converter(for: substituted)
         self.isTransferringRawValueType = swiftType.asStruct?.rawValueType(requiresTransferringRawValueType: true) != nil
+          || transferringRawValue
     }
 
     var generator: CodeGenerator
@@ -288,4 +305,13 @@ struct FlatRawRepresentableConverter: TypeConverter {
         )
         return decl
     }
+}
+
+fileprivate func extractOptions(_ parametersString: some StringProtocol) -> [Substring: Substring] {
+    let keyAndValues = parametersString
+        .split(separator: ",")
+        .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+        .compactMap({ $0.wholeMatch(of: /(\w+)\s*:\s*(.*)/) })
+        .map({ ($0.output.1, $0.output.2) })
+    return [Substring: Substring](uniqueKeysWithValues: keyAndValues)
 }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "483ee3e0b4181e6472604d1f21e3bf905f892c61",
-        "version" : "2.10.0"
+        "revision" : "8654d6ff35c9823cff38a6f9dd2aa0e6aed2769b",
+        "version" : "2.11.0"
       }
     },
     {
@@ -239,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
-        "version" : "508.0.0"
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "18ee757dbb9aac67fdbb71545e8c246f4248cbb0",
-        "version" : "2.6.2"
+        "revision" : "12390490318962cad1b82a5d4ee57363ff2dbdcf",
+        "version" : "2.8.0"
       }
     },
     {

--- a/example/Sources/APIDefinition/Echo.swift
+++ b/example/Sources/APIDefinition/Echo.swift
@@ -15,6 +15,7 @@ public protocol EchoServiceProtocol {
     func testRawRepr(request: Student2) async throws -> Student2
     func testRawRepr2(request: Student3) async throws -> Student3
     func testRawRepr3(request: Student4) async throws -> Student4
+    func testRawRepr4(request: Student5) async throws -> Student5
 }
 
 public struct EchoHelloRequest: Codable, Sendable {

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -26,3 +26,22 @@ public struct GenericID3<T>: Codable & RawRepresentable & Sendable {
     public typealias RawValue = MyValue
     public var rawValue: RawValue
 }
+
+/// @CallableKit(transferringRawValue: true)
+public struct GenericID4<_IDSpecifier, RawValue: Sendable & Codable>: RawRepresentable, Sendable, Codable {
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
+    public var rawValue: RawValue
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        id = try container.decode(RawValue.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/example/Sources/APIDefinition/Entity/GenericID.swift
+++ b/example/Sources/APIDefinition/Entity/GenericID.swift
@@ -37,7 +37,7 @@ public struct GenericID4<_IDSpecifier, RawValue: Sendable & Codable>: RawReprese
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        id = try container.decode(RawValue.self)
+        rawValue = try container.decode(RawValue.self)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/example/Sources/APIDefinition/Entity/Student.swift
+++ b/example/Sources/APIDefinition/Entity/Student.swift
@@ -41,3 +41,14 @@ public struct Student4: Codable, Sendable {
     public var id: ID
     public var name: String
 }
+
+public struct Student5: Codable, Sendable {
+    public typealias ID = GenericID4<Student4, String>
+
+    public init(id: ID, name: String) {
+        self.id = id
+        self.name = name
+    }
+    public var id: ID
+    public var name: String
+}

--- a/example/Sources/Client/Gen/Echo.gen.swift
+++ b/example/Sources/Client/Gen/Echo.gen.swift
@@ -34,6 +34,9 @@ public struct EchoServiceStub<C: StubClientProtocol>: EchoServiceProtocol, Senda
     public func testRawRepr3(request: Student4) async throws -> Student4 {
         return try await client.send(path: "Echo/testRawRepr3", request: request)
     }
+    public func testRawRepr4(request: Student5) async throws -> Student5 {
+        return try await client.send(path: "Echo/testRawRepr4", request: request)
+    }
 }
 
 extension StubClientProtocol {

--- a/example/Sources/Client/Main.swift
+++ b/example/Sources/Client/Main.swift
@@ -86,6 +86,15 @@ struct ErrorFrame: Decodable, CustomStringConvertible, LocalizedError {
         }
 
         do {
+            let student: Student5 = .init(
+                id: Student5.ID(rawValue: "0005"),
+                name: "taro"
+            )
+            let res = try await client.echo.testRawRepr4(request: student)
+            dump(res)
+        }
+
+        do {
             let res = try await client.account.signin(request: .init(
                 email: "example@example.com",
                 password: "password"

--- a/example/Sources/HBServer/Gen/Echo.gen.swift
+++ b/example/Sources/HBServer/Gen/Echo.gen.swift
@@ -15,4 +15,5 @@ func configureEchoService(
     router.post("Echo/testRawRepr", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr }))
     router.post("Echo/testRawRepr2", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr2 }))
     router.post("Echo/testRawRepr3", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr3 }))
+    router.post("Echo/testRawRepr4", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr4 }))
 }

--- a/example/Sources/Service/EchoService.swift
+++ b/example/Sources/Service/EchoService.swift
@@ -42,4 +42,8 @@ struct EchoService: EchoServiceProtocol {
     func testRawRepr3(request: Student4) async throws -> Student4 {
         return request
     }
+
+    func testRawRepr4(request: Student5) async throws -> Student5 {
+        return request
+    }
 }

--- a/example/Sources/VaporServer/Gen/Echo.gen.swift
+++ b/example/Sources/VaporServer/Gen/Echo.gen.swift
@@ -20,6 +20,7 @@ struct EchoServiceProvider<Bridge: VaporToServiceBridgeProtocol, Service: EchoSe
             group.post("testRawRepr", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr }))
             group.post("testRawRepr2", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr2 }))
             group.post("testRawRepr3", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr3 }))
+            group.post("testRawRepr4", use: bridge.makeHandler(serviceBuilder, { $0.testRawRepr4 }))
         }
     }
 }

--- a/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
@@ -19,7 +19,8 @@ import {
     Student4,
     Student4_JSON,
     Student4_decode,
-    Student4_encode
+    Student4_encode,
+    Student5
 } from "./Entity/Student.gen.js";
 import { User } from "./Entity/User.gen.js";
 
@@ -33,6 +34,7 @@ export interface IEchoClient {
     testRawRepr(request: Student2): Promise<Student2>;
     testRawRepr2(request: Student3): Promise<Student3>;
     testRawRepr3(request: Student4): Promise<Student4>;
+    testRawRepr4(request: Student5): Promise<Student5>;
 }
 
 export const bindEcho = (stub: IStubClient): IEchoClient => {
@@ -68,6 +70,9 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
         async testRawRepr3(request: Student4): Promise<Student4> {
             const json = await stub.send(Student4_encode(request), "Echo/testRawRepr3") as Student4_JSON;
             return Student4_decode(json);
+        },
+        async testRawRepr4(request: Student5): Promise<Student5> {
+            return await stub.send(request, "Echo/testRawRepr4") as Student5;
         }
     };
 };

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -89,3 +89,5 @@ export type GenericID3_RawValue_JSON = MyValue_JSON;
 export function GenericID3_RawValue_decode(json: GenericID3_RawValue_JSON): GenericID3_RawValue {
     return MyValue_decode(json);
 }
+
+export type GenericID4<_IDSpecifier, RawValue> = RawValue & TagRecord<"GenericID4", [_IDSpecifier, RawValue]>;

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -9,6 +9,7 @@ import {
     GenericID3_JSON,
     GenericID3_decode,
     GenericID3_encode,
+    GenericID4,
     MyValue,
     MyValue_JSON,
     MyValue_decode
@@ -174,3 +175,10 @@ export function Student4_ID_encode(entity: Student4_ID): Student4_ID_JSON {
         >(entity, Student4_encode, identity);
     });
 }
+
+export type Student5 = {
+    id: Student5_ID;
+    name: string;
+} & TagRecord<"Student5">;
+
+export type Student5_ID = GenericID4<Student4, string>;

--- a/example/TSClient/src/index.ts
+++ b/example/TSClient/src/index.ts
@@ -1,6 +1,6 @@
 import { bindAccount } from "./Gen/APIDefinition/Account.gen.js";
 import { bindEcho } from "./Gen/APIDefinition/Echo.gen.js";
-import { Student, Student2, Student3, Student4 } from "./Gen/APIDefinition/Entity/Student.gen.js";
+import { Student, Student2, Student3, Student4, Student5 } from "./Gen/APIDefinition/Entity/Student.gen.js";
 import { User_ID } from "./Gen/APIDefinition/Entity/User.gen.js";
 import { createStubClient } from "./Gen/CallableKit.gen.js";
 
@@ -76,6 +76,15 @@ async function main() {
       name: "taro"
     }
     const res = await echoClient.testRawRepr3(student);
+    console.log(JSON.stringify(res));
+  }
+
+  {
+    const student: Student5 = {
+      id: "0005",
+      name: "taro"
+    }
+    const res = await echoClient.testRawRepr4(student);
     console.log(JSON.stringify(res));
   }
 


### PR DESCRIPTION
下記のような形の、コメントによるアノテーション機能を追加する。
そして、そのアノテーションで与えるオプションとして `transferringRawValue` を追加する。

```
/// @CallableKit(transferringRawValue: true)
struct MyType {}
```

## `transferringRawValue` Option

付与された型のencoding/decodingが`rawValue`に転送されていることを示す。
自作のRawRepresentable型などに対して、JSON表現がSwift標準でない場合にその旨をTypeScript側に伝えるためのオプション。
TypeScriptがJSONからJSValueに変換する際のencode/decode関数の内容が変化し、`"rawValue"`を取り出したりする操作がスキップされる。