### PR TITLE
Scan service protocols using macro annotations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "958802e817d78436496ee4503e1c3cadce381499bd28d730810fcc15715bf1bd",
+  "originHash" : "49e633b3248491775b3e78a39e2300b207ade2ef8c7fa57307d0e1c93efa8d02",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "branch" : "attributes",
-        "revision" : "c89ae6dfab1b0e6c2552ac100578cec6e4470181"
+        "revision" : "be6697207cd9ed660499ea1a180919be8c857b8e",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "47b101acb5dce72e2df300bb54213e799129143e7ff1f087c6474d20f149c22f",
+  "originHash" : "958802e817d78436496ee4503e1c3cadce381499bd28d730810fcc15715bf1bd",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "8654d6ff35c9823cff38a6f9dd2aa0e6aed2769b",
-        "version" : "2.11.0"
+        "revision" : "e5a24cd47970a97700223fbfa6ba5d52113a0273",
+        "version" : "3.0.1"
       }
     },
     {
@@ -256,10 +256,10 @@
     {
       "identity" : "swifttypereader",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/SwiftTypeReader",
+      "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "revision" : "12390490318962cad1b82a5d4ee57363ff2dbdcf",
-        "version" : "2.8.0"
+        "branch" : "attributes",
+        "revision" : "c89ae6dfab1b0e6c2552ac100578cec6e4470181"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "c64e4a060a3daa9f8c964699ca4d8210235df20b",
-        "version" : "1.8.7"
+        "revision" : "4f6420d45d6dabc79b30954ea3aa524b7810a68b",
+        "version" : "2.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
         .package(url: "https://github.com/omochi/CodableToTypeScript.git", from: "3.0.1"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader.git", branch: "attributes"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader.git", from: "3.1.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.106.7"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
-        .package(url: "https://github.com/omochi/CodableToTypeScript.git", from: "2.11.0"),
-        .package(url: "https://github.com/omochi/SwiftTypeReader.git", from: "2.8.0"),
+        .package(url: "https://github.com/omochi/CodableToTypeScript.git", from: "3.0.1"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader.git", branch: "attributes"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.106.7"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
     ],

--- a/Sources/CallableKitMacros/CallableMacro.swift
+++ b/Sources/CallableKitMacros/CallableMacro.swift
@@ -13,7 +13,7 @@ public struct CallableMacro: PeerMacro {
         }
 
         let protocolName = `protocol`.name.trimmedDescription
-        let serviceName = protocolName.replacingOccurrences(of: "ServiceProtocol", with: "")
+        let serviceName = protocolName.trimmingSuffix("Protocol").trimmingSuffix("Service")
 
         let functions = `protocol`.memberBlock.members.compactMap { item in
             return item.decl.as(FunctionDeclSyntax.self)
@@ -40,5 +40,16 @@ public struct CallableMacro: PeerMacro {
         }
 
         return [DeclSyntax(configureFunc)]
+    }
+}
+
+extension String {
+    fileprivate func trimmingSuffix(_ suffix: String) -> String {
+        if self.hasSuffix(suffix) {
+            var copy = self
+            copy.removeLast(suffix.count)
+            return copy
+        }
+        return self
     }
 }

--- a/Sources/CodegenImpl/GenerateTSClient.swift
+++ b/Sources/CodegenImpl/GenerateTSClient.swift
@@ -271,8 +271,8 @@ struct FlatRawRepresentableConverter: TypeConverter {
         }
     }
 
-    func decodePresence() throws -> CodecPresence {
-        return isTransferringRawValueType ? .identity : .required
+    func hasDecode() -> Bool {
+        return !isTransferringRawValueType
     }
 
     func decodeDecl() throws -> TSFunctionDecl? {
@@ -288,8 +288,8 @@ struct FlatRawRepresentableConverter: TypeConverter {
         return decl
     }
 
-    func encodePresence() throws -> CodecPresence {
-        return isTransferringRawValueType ? .identity : .required
+    func hasEncode() -> Bool {
+        return !isTransferringRawValueType
     }
 
     func encodeDecl() throws -> TSFunctionDecl? {

--- a/Sources/CodegenImpl/ServiceProtocolScanner.swift
+++ b/Sources/CodegenImpl/ServiceProtocolScanner.swift
@@ -38,11 +38,11 @@ enum ServiceProtocolScanner {
 
     static func scan(_ stype: any SType) -> ServiceProtocolType? {
         guard let ptype = stype as? ProtocolType,
-              ptype.name.hasSuffix("ServiceProtocol"),
+              ptype.decl.attributes.contains(where: { $0.name == "Callable" }),
               !ptype.decl.functions.isEmpty
         else { return nil }
 
-        let serviceName = ptype.name.replacingOccurrences(of: "ServiceProtocol", with: "")
+        let serviceName = ptype.name.trimmingSuffix("Protocol").trimmingSuffix("Service")
 
         let functions = ptype.decl.functions.compactMap { fdecl -> ServiceProtocolType.Function? in
             guard fdecl.parameters.count <= 1 else {
@@ -75,5 +75,16 @@ enum ServiceProtocolScanner {
             functions: functions,
             raw: ptype
         )
+    }
+}
+
+extension String {
+    fileprivate func trimmingSuffix(_ suffix: String) -> String {
+        if self.hasSuffix(suffix) {
+            var copy = self
+            copy.removeLast(suffix.count)
+            return copy
+        }
+        return self
     }
 }

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "72222c8a5eb70b05fc61636aee7c555f6591c06635ec1a72b200e8f1ece362cb",
+  "originHash" : "f17cbec788f41a8520f2a0678c0cafe43ec3cc9c912babd1084f8df66e461370",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodableToTypeScript",
       "state" : {
-        "revision" : "8654d6ff35c9823cff38a6f9dd2aa0e6aed2769b",
-        "version" : "2.11.0"
+        "revision" : "e5a24cd47970a97700223fbfa6ba5d52113a0273",
+        "version" : "3.0.1"
       }
     },
     {
@@ -247,10 +247,10 @@
     {
       "identity" : "swifttypereader",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/SwiftTypeReader",
+      "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "revision" : "12390490318962cad1b82a5d4ee57363ff2dbdcf",
-        "version" : "2.8.0"
+        "branch" : "attributes",
+        "revision" : "c89ae6dfab1b0e6c2552ac100578cec6e4470181"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "c64e4a060a3daa9f8c964699ca4d8210235df20b",
-        "version" : "1.8.7"
+        "revision" : "4f6420d45d6dabc79b30954ea3aa524b7810a68b",
+        "version" : "2.0.1"
       }
     },
     {

--- a/example/Package.resolved
+++ b/example/Package.resolved
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "branch" : "attributes",
-        "revision" : "c89ae6dfab1b0e6c2552ac100578cec6e4470181"
+        "revision" : "be6697207cd9ed660499ea1a180919be8c857b8e",
+        "version" : "3.1.0"
       }
     },
     {

--- a/example/TSClient/src/Gen/APIDefinition/Account.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Account.gen.ts
@@ -1,5 +1,5 @@
 import { IStubClient } from "../CallableKit.gen.js";
-import { CodableResult, CodableResult_JSON, CodableResult_decode } from "../OtherDependency/CodableResult.gen.js";
+import { CodableResult, CodableResult$JSON, CodableResult_decode } from "../OtherDependency/CodableResult.gen.js";
 import { TagRecord, identity } from "../common.gen.js";
 import { SubmitError } from "./Entity/SubmitError.gen.js";
 
@@ -10,7 +10,7 @@ export interface IAccountClient {
 export const bindAccount = (stub: IStubClient): IAccountClient => {
     return {
         async signin(request: AccountSignin_Request): Promise<CodableResult<AccountSignin_Response, SubmitError<AccountSignin_Error>>> {
-            const json = await stub.send(request, "Account/signin") as CodableResult_JSON<AccountSignin_Response, SubmitError<AccountSignin_Error>>;
+            const json = await stub.send(request, "Account/signin") as CodableResult$JSON<AccountSignin_Response, SubmitError<AccountSignin_Error>>;
             return CodableResult_decode<
                 AccountSignin_Response,
                 AccountSignin_Response,

--- a/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Echo.gen.ts
@@ -9,15 +9,15 @@ import {
 import {
     Student,
     Student2,
-    Student2_JSON,
+    Student2$JSON,
     Student2_decode,
     Student2_encode,
     Student3,
-    Student3_JSON,
+    Student3$JSON,
     Student3_decode,
     Student3_encode,
     Student4,
-    Student4_JSON,
+    Student4$JSON,
     Student4_decode,
     Student4_encode,
     Student5
@@ -50,7 +50,7 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
             return await stub.send(request, "Echo/testTypicalEntity") as User;
         },
         async testComplexType(request: TestComplexType_Request): Promise<TestComplexType_Response> {
-            const json = await stub.send(request, "Echo/testComplexType") as TestComplexType_Response_JSON;
+            const json = await stub.send(request, "Echo/testComplexType") as TestComplexType_Response$JSON;
             return TestComplexType_Response_decode(json);
         },
         async emptyRequestAndResponse(): Promise<void> {
@@ -60,15 +60,15 @@ export const bindEcho = (stub: IStubClient): IEchoClient => {
             return await stub.send(request, "Echo/testTypeAliasToRawRepr") as Student;
         },
         async testRawRepr(request: Student2): Promise<Student2> {
-            const json = await stub.send(Student2_encode(request), "Echo/testRawRepr") as Student2_JSON;
+            const json = await stub.send(Student2_encode(request), "Echo/testRawRepr") as Student2$JSON;
             return Student2_decode(json);
         },
         async testRawRepr2(request: Student3): Promise<Student3> {
-            const json = await stub.send(Student3_encode(request), "Echo/testRawRepr2") as Student3_JSON;
+            const json = await stub.send(Student3_encode(request), "Echo/testRawRepr2") as Student3$JSON;
             return Student3_decode(json);
         },
         async testRawRepr3(request: Student4): Promise<Student4> {
-            const json = await stub.send(Student4_encode(request), "Echo/testRawRepr3") as Student4_JSON;
+            const json = await stub.send(Student4_encode(request), "Echo/testRawRepr3") as Student4$JSON;
             return Student4_decode(json);
         },
         async testRawRepr4(request: Student5): Promise<Student5> {
@@ -91,18 +91,18 @@ export type TestComplexType_K<T> = {
     x: T;
 } & TagRecord<"TestComplexType_K", [T]>;
 
-export type TestComplexType_K_JSON<T_JSON> = {
-    x: T_JSON;
+export type TestComplexType_K$JSON<T$JSON> = {
+    x: T$JSON;
 };
 
-export function TestComplexType_K_decode<T, T_JSON>(json: TestComplexType_K_JSON<T_JSON>, T_decode: (json: T_JSON) => T): TestComplexType_K<T> {
+export function TestComplexType_K_decode<T, T$JSON>(json: TestComplexType_K$JSON<T$JSON>, T_decode: (json: T$JSON) => T): TestComplexType_K<T> {
     const x = T_decode(json.x);
     return {
         x: x
     };
 }
 
-export function TestComplexType_K_encode<T, T_JSON>(entity: TestComplexType_K<T>, T_encode: (entity: T) => T_JSON): TestComplexType_K_JSON<T_JSON> {
+export function TestComplexType_K_encode<T, T$JSON>(entity: TestComplexType_K<T>, T_encode: (entity: T) => T$JSON): TestComplexType_K$JSON<T$JSON> {
     const x = T_encode(entity.x);
     return {
         x: x
@@ -124,9 +124,9 @@ export type TestComplexType_E<T> = ({
     n: {};
 }) & TagRecord<"TestComplexType_E", [T]>;
 
-export type TestComplexType_E_JSON<T_JSON> = {
+export type TestComplexType_E$JSON<T$JSON> = {
     k: {
-        _0: TestComplexType_K_JSON<T_JSON>;
+        _0: TestComplexType_K$JSON<T$JSON>;
     };
 } | {
     i: {
@@ -136,10 +136,10 @@ export type TestComplexType_E_JSON<T_JSON> = {
     n: {};
 };
 
-export function TestComplexType_E_decode<T, T_JSON>(json: TestComplexType_E_JSON<T_JSON>, T_decode: (json: T_JSON) => T): TestComplexType_E<T> {
+export function TestComplexType_E_decode<T, T$JSON>(json: TestComplexType_E$JSON<T$JSON>, T_decode: (json: T$JSON) => T): TestComplexType_E<T> {
     if ("k" in json) {
         const j = json.k;
-        const _0 = TestComplexType_K_decode<T, T_JSON>(j._0, T_decode);
+        const _0 = TestComplexType_K_decode<T, T$JSON>(j._0, T_decode);
         return {
             kind: "k",
             k: {
@@ -165,12 +165,12 @@ export function TestComplexType_E_decode<T, T_JSON>(json: TestComplexType_E_JSON
     }
 }
 
-export function TestComplexType_E_encode<T, T_JSON>(entity: TestComplexType_E<T>, T_encode: (entity: T) => T_JSON): TestComplexType_E_JSON<T_JSON> {
+export function TestComplexType_E_encode<T, T$JSON>(entity: TestComplexType_E<T>, T_encode: (entity: T) => T$JSON): TestComplexType_E$JSON<T$JSON> {
     switch (entity.kind) {
     case "k":
         {
             const e = entity.k;
-            const _0 = TestComplexType_K_encode<T, T_JSON>(e._0, T_encode);
+            const _0 = TestComplexType_K_encode<T, T$JSON>(e._0, T_encode);
             return {
                 k: {
                     _0: _0
@@ -207,15 +207,15 @@ export type TestComplexType_Request = {
     a?: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>;
 } & TagRecord<"TestComplexType_Request">;
 
-export type TestComplexType_Request_JSON = {
-    a?: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>;
+export type TestComplexType_Request$JSON = {
+    a?: TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>;
 };
 
-export function TestComplexType_Request_decode(json: TestComplexType_Request_JSON): TestComplexType_Request {
-    const a = OptionalField_decode<TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>, TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>>(json.a, (json: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
-        return TestComplexType_K_decode<(TestComplexType_E<TestComplexType_L> | null)[], (TestComplexType_E_JSON<TestComplexType_L> | null)[]>(json, (json: (TestComplexType_E_JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
-            return Array_decode<TestComplexType_E<TestComplexType_L> | null, TestComplexType_E_JSON<TestComplexType_L> | null>(json, (json: TestComplexType_E_JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
-                return Optional_decode<TestComplexType_E<TestComplexType_L>, TestComplexType_E_JSON<TestComplexType_L>>(json, (json: TestComplexType_E_JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
+export function TestComplexType_Request_decode(json: TestComplexType_Request$JSON): TestComplexType_Request {
+    const a = OptionalField_decode<TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>, TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>>(json.a, (json: TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
+        return TestComplexType_K_decode<(TestComplexType_E<TestComplexType_L> | null)[], (TestComplexType_E$JSON<TestComplexType_L> | null)[]>(json, (json: (TestComplexType_E$JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
+            return Array_decode<TestComplexType_E<TestComplexType_L> | null, TestComplexType_E$JSON<TestComplexType_L> | null>(json, (json: TestComplexType_E$JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
+                return Optional_decode<TestComplexType_E<TestComplexType_L>, TestComplexType_E$JSON<TestComplexType_L>>(json, (json: TestComplexType_E$JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
                     return TestComplexType_E_decode<TestComplexType_L, TestComplexType_L>(json, identity);
                 });
             });
@@ -230,15 +230,15 @@ export type TestComplexType_Response = {
     a?: TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>;
 } & TagRecord<"TestComplexType_Response">;
 
-export type TestComplexType_Response_JSON = {
-    a?: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>;
+export type TestComplexType_Response$JSON = {
+    a?: TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>;
 };
 
-export function TestComplexType_Response_decode(json: TestComplexType_Response_JSON): TestComplexType_Response {
-    const a = OptionalField_decode<TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>, TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>>(json.a, (json: TestComplexType_K_JSON<(TestComplexType_E_JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
-        return TestComplexType_K_decode<(TestComplexType_E<TestComplexType_L> | null)[], (TestComplexType_E_JSON<TestComplexType_L> | null)[]>(json, (json: (TestComplexType_E_JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
-            return Array_decode<TestComplexType_E<TestComplexType_L> | null, TestComplexType_E_JSON<TestComplexType_L> | null>(json, (json: TestComplexType_E_JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
-                return Optional_decode<TestComplexType_E<TestComplexType_L>, TestComplexType_E_JSON<TestComplexType_L>>(json, (json: TestComplexType_E_JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
+export function TestComplexType_Response_decode(json: TestComplexType_Response$JSON): TestComplexType_Response {
+    const a = OptionalField_decode<TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]>, TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>>(json.a, (json: TestComplexType_K$JSON<(TestComplexType_E$JSON<TestComplexType_L> | null)[]>): TestComplexType_K<(TestComplexType_E<TestComplexType_L> | null)[]> => {
+        return TestComplexType_K_decode<(TestComplexType_E<TestComplexType_L> | null)[], (TestComplexType_E$JSON<TestComplexType_L> | null)[]>(json, (json: (TestComplexType_E$JSON<TestComplexType_L> | null)[]): (TestComplexType_E<TestComplexType_L> | null)[] => {
+            return Array_decode<TestComplexType_E<TestComplexType_L> | null, TestComplexType_E$JSON<TestComplexType_L> | null>(json, (json: TestComplexType_E$JSON<TestComplexType_L> | null): TestComplexType_E<TestComplexType_L> | null => {
+                return Optional_decode<TestComplexType_E<TestComplexType_L>, TestComplexType_E$JSON<TestComplexType_L>>(json, (json: TestComplexType_E$JSON<TestComplexType_L>): TestComplexType_E<TestComplexType_L> => {
                     return TestComplexType_E_decode<TestComplexType_L, TestComplexType_L>(json, identity);
                 });
             });

--- a/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/GenericID.gen.ts
@@ -4,25 +4,25 @@ export type GenericID<T> = string & TagRecord<"GenericID", [T]>;
 
 export type GenericID2<_IDSpecifier, RawValue> = RawValue & TagRecord<"GenericID2", [_IDSpecifier, RawValue]>;
 
-export type GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> = {
-    rawValue: RawValue_JSON;
+export type GenericID2$JSON<_IDSpecifier$JSON, RawValue$JSON> = {
+    rawValue: RawValue$JSON;
 };
 
 export function GenericID2_decode<
     _IDSpecifier,
-    _IDSpecifier_JSON,
+    _IDSpecifier$JSON,
     RawValue,
-    RawValue_JSON
->(json: GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON>, _IDSpecifier_decode: (json: _IDSpecifier_JSON) => _IDSpecifier, RawValue_decode: (json: RawValue_JSON) => RawValue): GenericID2<_IDSpecifier, RawValue> {
+    RawValue$JSON
+>(json: GenericID2$JSON<_IDSpecifier$JSON, RawValue$JSON>, _IDSpecifier_decode: (json: _IDSpecifier$JSON) => _IDSpecifier, RawValue_decode: (json: RawValue$JSON) => RawValue): GenericID2<_IDSpecifier, RawValue> {
     return RawValue_decode(json.rawValue) as GenericID2<_IDSpecifier, RawValue>;
 }
 
 export function GenericID2_encode<
     _IDSpecifier,
-    _IDSpecifier_JSON,
+    _IDSpecifier$JSON,
     RawValue,
-    RawValue_JSON
->(entity: GenericID2<_IDSpecifier, RawValue>, _IDSpecifier_encode: (entity: _IDSpecifier) => _IDSpecifier_JSON, RawValue_encode: (entity: RawValue) => RawValue_JSON): GenericID2_JSON<_IDSpecifier_JSON, RawValue_JSON> {
+    RawValue$JSON
+>(entity: GenericID2<_IDSpecifier, RawValue>, _IDSpecifier_encode: (entity: _IDSpecifier) => _IDSpecifier$JSON, RawValue_encode: (entity: RawValue) => RawValue$JSON): GenericID2$JSON<_IDSpecifier$JSON, RawValue$JSON> {
     return {
         rawValue: RawValue_encode(entity)
     };
@@ -38,7 +38,7 @@ export type MyValue = ({
     none: {};
 }) & TagRecord<"MyValue">;
 
-export type MyValue_JSON = {
+export type MyValue$JSON = {
     id: {
         _0: string;
     };
@@ -46,7 +46,7 @@ export type MyValue_JSON = {
     none: {};
 };
 
-export function MyValue_decode(json: MyValue_JSON): MyValue {
+export function MyValue_decode(json: MyValue$JSON): MyValue {
     if ("id" in json) {
         const j = json.id;
         const _0 = j._0;
@@ -68,25 +68,25 @@ export function MyValue_decode(json: MyValue_JSON): MyValue {
 
 export type GenericID3<T> = MyValue & TagRecord<"GenericID3", [T]>;
 
-export type GenericID3_JSON<T_JSON> = {
-    rawValue: MyValue_JSON;
+export type GenericID3$JSON<T$JSON> = {
+    rawValue: MyValue$JSON;
 };
 
-export function GenericID3_decode<T, T_JSON>(json: GenericID3_JSON<T_JSON>, T_decode: (json: T_JSON) => T): GenericID3<T> {
+export function GenericID3_decode<T, T$JSON>(json: GenericID3$JSON<T$JSON>, T_decode: (json: T$JSON) => T): GenericID3<T> {
     return MyValue_decode(json.rawValue) as GenericID3<T>;
 }
 
-export function GenericID3_encode<T, T_JSON>(entity: GenericID3<T>, T_encode: (entity: T) => T_JSON): GenericID3_JSON<T_JSON> {
+export function GenericID3_encode<T, T$JSON>(entity: GenericID3<T>, T_encode: (entity: T) => T$JSON): GenericID3$JSON<T$JSON> {
     return {
-        rawValue: entity as MyValue_JSON
+        rawValue: entity as MyValue$JSON
     };
 }
 
-export type GenericID3_RawValue = MyValue;
+export type GenericID3_RawValue<T> = MyValue;
 
-export type GenericID3_RawValue_JSON = MyValue_JSON;
+export type GenericID3_RawValue$JSON<T$JSON> = MyValue$JSON;
 
-export function GenericID3_RawValue_decode(json: GenericID3_RawValue_JSON): GenericID3_RawValue {
+export function GenericID3_RawValue_decode<T, T$JSON>(json: GenericID3_RawValue$JSON<T$JSON>, T_decode: (json: T$JSON) => T): GenericID3_RawValue<T> {
     return MyValue_decode(json);
 }
 

--- a/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/Student.gen.ts
@@ -2,16 +2,16 @@ import { TagRecord, identity } from "../../common.gen.js";
 import {
     GenericID,
     GenericID2,
-    GenericID2_JSON,
+    GenericID2$JSON,
     GenericID2_decode,
     GenericID2_encode,
     GenericID3,
-    GenericID3_JSON,
+    GenericID3$JSON,
     GenericID3_decode,
     GenericID3_encode,
     GenericID4,
     MyValue,
-    MyValue_JSON,
+    MyValue$JSON,
     MyValue_decode
 } from "./GenericID.gen.js";
 
@@ -27,12 +27,12 @@ export type Student2 = {
     name: string;
 } & TagRecord<"Student2">;
 
-export type Student2_JSON = {
-    id: Student2_ID_JSON;
+export type Student2$JSON = {
+    id: Student2_ID$JSON;
     name: string;
 };
 
-export function Student2_decode(json: Student2_JSON): Student2 {
+export function Student2_decode(json: Student2$JSON): Student2 {
     const id = Student2_ID_decode(json.id);
     const name = json.name;
     return {
@@ -41,7 +41,7 @@ export function Student2_decode(json: Student2_JSON): Student2 {
     };
 }
 
-export function Student2_encode(entity: Student2): Student2_JSON {
+export function Student2_encode(entity: Student2): Student2$JSON {
     const id = Student2_ID_encode(entity.id);
     const name = entity.name;
     return {
@@ -52,21 +52,21 @@ export function Student2_encode(entity: Student2): Student2_JSON {
 
 export type Student2_ID = GenericID2<Student2, string>;
 
-export type Student2_ID_JSON = GenericID2_JSON<Student2_JSON, string>;
+export type Student2_ID$JSON = GenericID2$JSON<Student2$JSON, string>;
 
-export function Student2_ID_decode(json: Student2_ID_JSON): Student2_ID {
+export function Student2_ID_decode(json: Student2_ID$JSON): Student2_ID {
     return GenericID2_decode<
         Student2,
-        Student2_JSON,
+        Student2$JSON,
         string,
         string
     >(json, Student2_decode, identity);
 }
 
-export function Student2_ID_encode(entity: Student2_ID): Student2_ID_JSON {
+export function Student2_ID_encode(entity: Student2_ID): Student2_ID$JSON {
     return GenericID2_encode<
         Student2,
-        Student2_JSON,
+        Student2$JSON,
         string,
         string
     >(entity, Student2_encode, identity);
@@ -77,12 +77,12 @@ export type Student3 = {
     name: string;
 } & TagRecord<"Student3">;
 
-export type Student3_JSON = {
-    id: Student3_ID_JSON;
+export type Student3$JSON = {
+    id: Student3_ID$JSON;
     name: string;
 };
 
-export function Student3_decode(json: Student3_JSON): Student3 {
+export function Student3_decode(json: Student3$JSON): Student3 {
     const id = Student3_ID_decode(json.id);
     const name = json.name;
     return {
@@ -91,7 +91,7 @@ export function Student3_decode(json: Student3_JSON): Student3 {
     };
 }
 
-export function Student3_encode(entity: Student3): Student3_JSON {
+export function Student3_encode(entity: Student3): Student3$JSON {
     const id = Student3_ID_encode(entity.id);
     const name = entity.name;
     return {
@@ -102,14 +102,14 @@ export function Student3_encode(entity: Student3): Student3_JSON {
 
 export type Student3_ID = GenericID3<Student3>;
 
-export type Student3_ID_JSON = GenericID3_JSON<Student3_JSON>;
+export type Student3_ID$JSON = GenericID3$JSON<Student3$JSON>;
 
-export function Student3_ID_decode(json: Student3_ID_JSON): Student3_ID {
-    return GenericID3_decode<Student3, Student3_JSON>(json, Student3_decode);
+export function Student3_ID_decode(json: Student3_ID$JSON): Student3_ID {
+    return GenericID3_decode<Student3, Student3$JSON>(json, Student3_decode);
 }
 
-export function Student3_ID_encode(entity: Student3_ID): Student3_ID_JSON {
-    return GenericID3_encode<Student3, Student3_JSON>(entity, Student3_encode);
+export function Student3_ID_encode(entity: Student3_ID): Student3_ID$JSON {
+    return GenericID3_encode<Student3, Student3$JSON>(entity, Student3_encode);
 }
 
 export type Student4 = {
@@ -117,12 +117,12 @@ export type Student4 = {
     name: string;
 } & TagRecord<"Student4">;
 
-export type Student4_JSON = {
-    id: Student4_ID_JSON;
+export type Student4$JSON = {
+    id: Student4_ID$JSON;
     name: string;
 };
 
-export function Student4_decode(json: Student4_JSON): Student4 {
+export function Student4_decode(json: Student4$JSON): Student4 {
     const id = Student4_ID_decode(json.id);
     const name = json.name;
     return {
@@ -131,7 +131,7 @@ export function Student4_decode(json: Student4_JSON): Student4 {
     };
 }
 
-export function Student4_encode(entity: Student4): Student4_JSON {
+export function Student4_encode(entity: Student4): Student4$JSON {
     const id = Student4_ID_encode(entity.id);
     const name = entity.name;
     return {
@@ -142,36 +142,36 @@ export function Student4_encode(entity: Student4): Student4_JSON {
 
 export type Student4_ID = GenericID2<Student4, GenericID2<Student4, MyValue>>;
 
-export type Student4_ID_JSON = GenericID2_JSON<Student4_JSON, GenericID2_JSON<Student4_JSON, MyValue_JSON>>;
+export type Student4_ID$JSON = GenericID2$JSON<Student4$JSON, GenericID2$JSON<Student4$JSON, MyValue$JSON>>;
 
-export function Student4_ID_decode(json: Student4_ID_JSON): Student4_ID {
+export function Student4_ID_decode(json: Student4_ID$JSON): Student4_ID {
     return GenericID2_decode<
         Student4,
-        Student4_JSON,
+        Student4$JSON,
         GenericID2<Student4, MyValue>,
-        GenericID2_JSON<Student4_JSON, MyValue_JSON>
-    >(json, Student4_decode, (json: GenericID2_JSON<Student4_JSON, MyValue_JSON>): GenericID2<Student4, MyValue> => {
+        GenericID2$JSON<Student4$JSON, MyValue$JSON>
+    >(json, Student4_decode, (json: GenericID2$JSON<Student4$JSON, MyValue$JSON>): GenericID2<Student4, MyValue> => {
         return GenericID2_decode<
             Student4,
-            Student4_JSON,
+            Student4$JSON,
             MyValue,
-            MyValue_JSON
+            MyValue$JSON
         >(json, Student4_decode, MyValue_decode);
     });
 }
 
-export function Student4_ID_encode(entity: Student4_ID): Student4_ID_JSON {
+export function Student4_ID_encode(entity: Student4_ID): Student4_ID$JSON {
     return GenericID2_encode<
         Student4,
-        Student4_JSON,
+        Student4$JSON,
         GenericID2<Student4, MyValue>,
-        GenericID2_JSON<Student4_JSON, MyValue_JSON>
-    >(entity, Student4_encode, (entity: GenericID2<Student4, MyValue>): GenericID2_JSON<Student4_JSON, MyValue_JSON> => {
+        GenericID2$JSON<Student4$JSON, MyValue$JSON>
+    >(entity, Student4_encode, (entity: GenericID2<Student4, MyValue>): GenericID2$JSON<Student4$JSON, MyValue$JSON> => {
         return GenericID2_encode<
             Student4,
-            Student4_JSON,
+            Student4$JSON,
             MyValue,
-            MyValue_JSON
+            MyValue$JSON
         >(entity, Student4_encode, identity);
     });
 }

--- a/example/TSClient/src/Gen/APIDefinition/Entity/SubmitError.gen.ts
+++ b/example/TSClient/src/Gen/APIDefinition/Entity/SubmitError.gen.ts
@@ -5,12 +5,12 @@ export type InputFieldError<E> = {
     message: string;
 } & TagRecord<"InputFieldError", [E]>;
 
-export type InputFieldError_JSON<E_JSON> = {
-    name: E_JSON;
+export type InputFieldError$JSON<E$JSON> = {
+    name: E$JSON;
     message: string;
 };
 
-export function InputFieldError_decode<E, E_JSON>(json: InputFieldError_JSON<E_JSON>, E_decode: (json: E_JSON) => E): InputFieldError<E> {
+export function InputFieldError_decode<E, E$JSON>(json: InputFieldError$JSON<E$JSON>, E_decode: (json: E$JSON) => E): InputFieldError<E> {
     const name = E_decode(json.name);
     const message = json.message;
     return {
@@ -19,7 +19,7 @@ export function InputFieldError_decode<E, E_JSON>(json: InputFieldError_JSON<E_J
     };
 }
 
-export function InputFieldError_encode<E, E_JSON>(entity: InputFieldError<E>, E_encode: (entity: E) => E_JSON): InputFieldError_JSON<E_JSON> {
+export function InputFieldError_encode<E, E$JSON>(entity: InputFieldError<E>, E_encode: (entity: E) => E$JSON): InputFieldError$JSON<E$JSON> {
     const name = E_encode(entity.name);
     const message = entity.message;
     return {
@@ -32,22 +32,22 @@ export type SubmitError<E> = {
     errors: InputFieldError<E>[];
 } & TagRecord<"SubmitError", [E]>;
 
-export type SubmitError_JSON<E_JSON> = {
-    errors: InputFieldError_JSON<E_JSON>[];
+export type SubmitError$JSON<E$JSON> = {
+    errors: InputFieldError$JSON<E$JSON>[];
 };
 
-export function SubmitError_decode<E, E_JSON>(json: SubmitError_JSON<E_JSON>, E_decode: (json: E_JSON) => E): SubmitError<E> {
-    const errors = Array_decode<InputFieldError<E>, InputFieldError_JSON<E_JSON>>(json.errors, (json: InputFieldError_JSON<E_JSON>): InputFieldError<E> => {
-        return InputFieldError_decode<E, E_JSON>(json, E_decode);
+export function SubmitError_decode<E, E$JSON>(json: SubmitError$JSON<E$JSON>, E_decode: (json: E$JSON) => E): SubmitError<E> {
+    const errors = Array_decode<InputFieldError<E>, InputFieldError$JSON<E$JSON>>(json.errors, (json: InputFieldError$JSON<E$JSON>): InputFieldError<E> => {
+        return InputFieldError_decode<E, E$JSON>(json, E_decode);
     });
     return {
         errors: errors
     };
 }
 
-export function SubmitError_encode<E, E_JSON>(entity: SubmitError<E>, E_encode: (entity: E) => E_JSON): SubmitError_JSON<E_JSON> {
-    const errors = Array_encode<InputFieldError<E>, InputFieldError_JSON<E_JSON>>(entity.errors, (entity: InputFieldError<E>): InputFieldError_JSON<E_JSON> => {
-        return InputFieldError_encode<E, E_JSON>(entity, E_encode);
+export function SubmitError_encode<E, E$JSON>(entity: SubmitError<E>, E_encode: (entity: E) => E$JSON): SubmitError$JSON<E$JSON> {
+    const errors = Array_encode<InputFieldError<E>, InputFieldError$JSON<E$JSON>>(entity.errors, (entity: InputFieldError<E>): InputFieldError$JSON<E$JSON> => {
+        return InputFieldError_encode<E, E$JSON>(entity, E_encode);
     });
     return {
         errors: errors

--- a/example/TSClient/src/Gen/OtherDependency/CodableResult.gen.ts
+++ b/example/TSClient/src/Gen/OtherDependency/CodableResult.gen.ts
@@ -12,22 +12,22 @@ export type CodableResult<T, E> = ({
     };
 }) & TagRecord<"CodableResult", [T, E]>;
 
-export type CodableResult_JSON<T_JSON, E_JSON> = {
+export type CodableResult$JSON<T$JSON, E$JSON> = {
     success: {
-        _0: T_JSON;
+        _0: T$JSON;
     };
 } | {
     failure: {
-        _0: E_JSON;
+        _0: E$JSON;
     };
 };
 
 export function CodableResult_decode<
     T,
-    T_JSON,
+    T$JSON,
     E,
-    E_JSON
->(json: CodableResult_JSON<T_JSON, E_JSON>, T_decode: (json: T_JSON) => T, E_decode: (json: E_JSON) => E): CodableResult<T, E> {
+    E$JSON
+>(json: CodableResult$JSON<T$JSON, E$JSON>, T_decode: (json: T$JSON) => T, E_decode: (json: E$JSON) => E): CodableResult<T, E> {
     if ("success" in json) {
         const j = json.success;
         const _0 = T_decode(j._0);
@@ -53,10 +53,10 @@ export function CodableResult_decode<
 
 export function CodableResult_encode<
     T,
-    T_JSON,
+    T$JSON,
     E,
-    E_JSON
->(entity: CodableResult<T, E>, T_encode: (entity: T) => T_JSON, E_encode: (entity: E) => E_JSON): CodableResult_JSON<T_JSON, E_JSON> {
+    E$JSON
+>(entity: CodableResult<T, E>, T_encode: (entity: T) => T$JSON, E_encode: (entity: E) => E$JSON): CodableResult$JSON<T$JSON, E$JSON> {
     switch (entity.kind) {
     case "success":
         {

--- a/example/TSClient/src/Gen/common.gen.ts
+++ b/example/TSClient/src/Gen/common.gen.ts
@@ -2,37 +2,45 @@ export function identity<T>(json: T): T {
     return json;
 }
 
-export function OptionalField_decode<T, T_JSON>(json: T_JSON | undefined, T_decode: (json: T_JSON) => T): T | undefined {
+export function OptionalField_decode<T, T$JSON>(json: T$JSON | undefined, T_decode: (json: T$JSON) => T): T | undefined {
     if (json === undefined) return undefined;
     return T_decode(json);
 }
 
-export function OptionalField_encode<T, T_JSON>(entity: T | undefined, T_encode: (entity: T) => T_JSON): T_JSON | undefined {
+export function OptionalField_encode<T, T$JSON>(entity: T | undefined, T_encode: (entity: T) => T$JSON): T$JSON | undefined {
     if (entity === undefined) return undefined;
     return T_encode(entity);
 }
 
-export function Optional_decode<T, T_JSON>(json: T_JSON | null, T_decode: (json: T_JSON) => T): T | null {
+export function Optional_decode<T, T$JSON>(json: T$JSON | null, T_decode: (json: T$JSON) => T): T | null {
     if (json === null) return null;
     return T_decode(json);
 }
 
-export function Optional_encode<T, T_JSON>(entity: T | null, T_encode: (entity: T) => T_JSON): T_JSON | null {
+export function Optional_encode<T, T$JSON>(entity: T | null, T_encode: (entity: T) => T$JSON): T$JSON | null {
     if (entity === null) return null;
     return T_encode(entity);
 }
 
-export function Array_decode<T, T_JSON>(json: T_JSON[], T_decode: (json: T_JSON) => T): T[] {
+export function Array_decode<T, T$JSON>(json: T$JSON[], T_decode: (json: T$JSON) => T): T[] {
     return json.map(T_decode);
 }
 
-export function Array_encode<T, T_JSON>(entity: T[], T_encode: (entity: T) => T_JSON): T_JSON[] {
+export function Array_encode<T, T$JSON>(entity: T[], T_encode: (entity: T) => T$JSON): T$JSON[] {
     return entity.map(T_encode);
 }
 
-export function Dictionary_decode<T, T_JSON>(json: {
-    [key: string]: T_JSON;
-}, T_decode: (json: T_JSON) => T): Map<string, T> {
+export function Set_decode<T, T$JSON>(json: T$JSON[], T_decode: (json: T$JSON) => T): Set<T> {
+    return new Set(json.map(T_decode));
+}
+
+export function Set_encode<T, T$JSON>(entity: Set<T>, T_encode: (entity: T) => T$JSON): T$JSON[] {
+    return [... entity].map(T_encode);
+}
+
+export function Dictionary_decode<T, T$JSON>(json: {
+    [key: string]: T$JSON;
+}, T_decode: (json: T$JSON) => T): Map<string, T> {
     const entity = new Map<string, T>();
     for (const k in json) {
         if (json.hasOwnProperty(k)) {
@@ -42,11 +50,11 @@ export function Dictionary_decode<T, T_JSON>(json: {
     return entity;
 }
 
-export function Dictionary_encode<T, T_JSON>(entity: Map<string, T>, T_encode: (entity: T) => T_JSON): {
-    [key: string]: T_JSON;
+export function Dictionary_encode<T, T$JSON>(entity: Map<string, T>, T_encode: (entity: T) => T$JSON): {
+    [key: string]: T$JSON;
 } {
     const json: {
-        [key: string]: T_JSON;
+        [key: string]: T$JSON;
     } = {};
     for (const k in entity.keys()) {
         json[k] = T_encode(entity.get(k) !!);


### PR DESCRIPTION
これでまではコード生成対象の特定には`~ServiceProtocol`というSuffixを持ったprotocolを探索していたが、#35 でサーバ側においてはマクロを使ったコード生成に切り替わった。
これにより、コード生成対象の特定方法がマクロと外部executableの間でズレる形になった。

このズレを統一するために、外部executableがコード生成対象を特定する際にマクロのアノテーションを探索させる。
