### PR TITLE
Allow async and throwing for service builder

### DIFF
--- a/example/Sources/HBServer/HBMain.swift
+++ b/example/Sources/HBServer/HBMain.swift
@@ -29,7 +29,7 @@ struct ErrorMiddleware<Context: RequestContext>: MiddlewareProtocol {
         router.add(middleware: ErrorMiddleware())
 
         configureAccountServiceProtocol(transport: HummingbirdTransport(router: router) { _, _ in
-            makeAccountService()
+            try await makeAccountService()
         })
         configureEchoServiceProtocol(transport: HummingbirdTransport(router: router) { _, _ in
             makeEchoService()

--- a/example/Sources/Service/AccountService.swift
+++ b/example/Sources/Service/AccountService.swift
@@ -1,7 +1,7 @@
 import APIDefinition
 import OtherDependency
 
-public func makeAccountService() -> some AccountServiceProtocol {
+public func makeAccountService() async throws -> some AccountServiceProtocol {
     AccountService()
 }
 

--- a/example/Sources/VaporServer/VaporMain.swift
+++ b/example/Sources/VaporServer/VaporMain.swift
@@ -25,7 +25,7 @@ import Service
 
         app.group(myErrorMiddleware) { routes in
             configureAccountServiceProtocol(transport: VaporTransport(router: routes) { _ in
-                makeAccountService()
+                try await makeAccountService()
             })
             configureEchoServiceProtocol(transport: VaporTransport(router: routes) { _ in
                 makeEchoService()


### PR DESCRIPTION
VaporTransport及びHummingbirdTransportにおいて、Serviceの生成が非同期の場合もあることを忘れていた。単に引数をasync throws化する。