### PR TITLE
Set min platform versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,13 @@ import PackageDescription
 
 let package = Package(
     name: "CallableKit",
-    platforms: [.macOS(.v14)],
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macCatalyst(.v13),
+    ],
     products: [
         .library(name: "CallableKit", targets: ["CallableKit"]),
         .library(name: "CallableKitURLSessionStub", targets: ["CallableKitURLSessionStub"]),

--- a/Sources/CallableKitURLSessionStub/URLSessionStubClient.swift
+++ b/Sources/CallableKitURLSessionStub/URLSessionStubClient.swift
@@ -98,6 +98,7 @@ private func makeEncoder() -> JSONEncoder {
     return encoder
 }
 
+#if compiler(<6.0)
 #if canImport(FoundationNetworking)
 extension URLSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
@@ -120,4 +121,5 @@ extension URLSession {
         })
     }
 }
+#endif
 #endif


### PR DESCRIPTION
It cannot build on iOS because `swift-syntax` needs min iOS version 13.
Should be set platform versions.